### PR TITLE
Fix hardcoded TLS ignore verify

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -75,7 +75,6 @@ class AdminObject(object):
             request_url,
             json=data_json,
             headers={'Content-Type': 'application/json'},
-            verify=False,
             auth=self._auth,
         )
         r.raise_for_status()
@@ -101,7 +100,6 @@ class AdminObject(object):
         request_url = self._artifactory.drive + '/api/{uri}/{x.name}'.format(uri=self._uri, x=self)
         r = self._session.get(
             request_url,
-            verify=False,
             auth=self._auth,
         )
         if 404 == r.status_code or 400 == r.status_code:
@@ -132,7 +130,6 @@ class AdminObject(object):
         request_url = self._artifactory.drive + '/api/{uri}/{x.name}'.format(uri=self._uri, x=self)
         r = self._session.delete(
             request_url,
-            verify=False,
             auth=self._auth,
         )
         r.raise_for_status()
@@ -199,7 +196,6 @@ class User(AdminObject):
         request_url = self._artifactory.drive + '/api/security/encryptedPassword'
         r = self._session.get(
             request_url,
-            verify=False,
             auth=(self.name, self.password),
         )
         r.raise_for_status()


### PR DESCRIPTION
This is a security bug, `verify` is already defined by the `session` object and shouldn't be overwritten by separate function calls.

I've tested it and it seems to work for me.
I'm initializing my artifactory class by this way and the certificate checks are finally not ignored anymore.

```
ses = requests.Session()
ses.auth = (user, secret)
ses.verify = "./path-to-certifiacte.pem"
artifactoryInstance = ArtifactoryPath(a["url"] + "/artifactory", session=ses)
```

Please test those changes, I'm worried of breaking things this way.