### PR TITLE
Use requests.auth.HTTPDigestAuth as default authentication

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -901,7 +901,8 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.session = kwargs.get('session', None)
 
         if obj.auth is None and cfg_entry:
-            obj.auth = (cfg_entry['username'], cfg_entry['password'])
+            obj.auth = requests.auth.HTTPDigestAuth(cfg_entry['username'],
+                                                    cfg_entry['password'])
 
         if obj.cert is None and cfg_entry:
             obj.cert = cfg_entry['cert']


### PR DESCRIPTION
The server respondes 401 Unauthorized, and provide a authentication realm and a nonce, so HTTPDigestAuth can present properly the password and re-send the same request.

For more information, see https://en.wikipedia.org/wiki/Digest_access_authentication#Example_with_explanation.

Fix #46.