### PR TITLE
Add Sha-256 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ nosetests.xml
 .project
 .pydevproject
 .idea
+.vscode/
+.venv/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This module is intended to serve as a logical descendant of [pathlib](https://docs.python.org/3/library/pathlib.html), a Python 3 module for object-oriented path manipulations. As such, it implements everything as closely as possible to the origin with few exceptions, such as stat().
 
-# Tables of Contents 
+# Tables of Contents
 - [Install](#install)
 - [Usage](#usage)
     - [Authentication](#authentication)
@@ -38,7 +38,7 @@ This module is intended to serve as a logical descendant of [pathlib](https://do
 ```bash
 python3 -mpip install dohq-artifactory
 ```
-# Usage 
+# Usage
 
 ## Authentication ##
 `dohq-artifactory` support this way to authentication:
@@ -64,7 +64,7 @@ path = ArtifactoryPath(
     "http://my-artifactory/artifactory/myrepo/restricted-path",
     auth=('USERNAME', 'PASSWORD'),
     auth_type=HTTPDigestAuth,
-    
+
     )
 
 from requests.auth import HTTPBasicAuth
@@ -114,7 +114,7 @@ Download artifact to a local filesystem:
 from artifactory import ArtifactoryPath
 path = ArtifactoryPath(
     "http://repo.jfrog.org/artifactory/distributions/org/apache/tomcat/apache-tomcat-7.0.11.tar.gz")
-    
+
 with path.open() as fd:
     with open("tomcat.tar.gz", "wb") as out:
         out.write(fd.read())
@@ -138,7 +138,7 @@ Deploy a debian package ```myapp-1.0.deb```
 from artifactory import ArtifactoryPath
 path = ArtifactoryPath(
     "http://my-artifactory/artifactory/ubuntu-local/pool")
-path.deploy_deb('./myapp-1.0.deb', 
+path.deploy_deb('./myapp-1.0.deb',
                 distribution='trusty',
                 component='main',
                 architecture='amd64')
@@ -274,7 +274,7 @@ artifact_pathlib_list = list(map(aql.from_aql, artifacts_list))
 
 
 ## FileStat
-You can get hash (`md5`, `sha1`), create and change date:
+You can get hash (`md5`, `sha1`, `sha256`), create and change date:
 
 ```python
 from artifactory import ArtifactoryPath
@@ -286,6 +286,7 @@ stat = ArtifactoryPath.stat(path)
 print(stat)
 print(stat.md5)
 print(stat.sha1)
+print(stat.sha256)
 print(stat.ctime)
 print(stat.is_dir)
 print(stat.size)
@@ -480,7 +481,7 @@ path.touch()
 
 
 ## SSL Cert Verification Options ##
-See [Requests - SSL verification](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) for more details.  
+See [Requests - SSL verification](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) for more details.
 
 ```python
 from artifactory import ArtifactoryPath
@@ -491,7 +492,7 @@ path = ArtifactoryPath(
 ```python
 from artifactory import ArtifactoryPath
 path = ArtifactoryPath(
-    "http://my-artifactory/artifactory/libs-snapshot-local/myapp/1.0", 
+    "http://my-artifactory/artifactory/libs-snapshot-local/myapp/1.0",
     verify=True)
 ```
 Specify a local cert to use as client side certificate
@@ -502,7 +503,7 @@ path = ArtifactoryPath(
     "http://my-artifactory/artifactory/libs-snapshot-local/myapp/1.0",
     cert="/path_to_file/server.pem")
 ```
-Disable host cert verification 
+Disable host cert verification
 
 ```python
 from artifactory import ArtifactoryPath
@@ -511,7 +512,7 @@ path = ArtifactoryPath(
     verify=False)
 ```
 
-**Note:** If host cert verification is disabled urllib3 will throw a [InsecureRequestWarning](https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning).  
+**Note:** If host cert verification is disabled urllib3 will throw a [InsecureRequestWarning](https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning).
 To disable these warning, one needs to call urllib3.disable_warnings().
 ```python
 import requests.packages.urllib3 as urllib3
@@ -552,7 +553,7 @@ password = @dmin
 cert = ~/mycert
 ```
 
-Whether or not you specify ```http://``` or ```https://``` prefix is not essential. The module will first try to locate the best match and then try to match URLs without prefixes. So if in the config you specify ```https://my-instance.local``` and call ```ArtifactoryPath``` with ```http://my-instance.local```, it will still do the right thing. 
+Whether or not you specify ```http://``` or ```https://``` prefix is not essential. The module will first try to locate the best match and then try to match URLs without prefixes. So if in the config you specify ```https://my-instance.local``` and call ```ArtifactoryPath``` with ```http://my-instance.local```, it will still do the right thing.
 
 
 # Contribute
@@ -561,6 +562,3 @@ Whether or not you specify ```http://``` or ```https://``` prefix is not essenti
 # Advertising
 - [artifactory-du](https://github.com/devopshq/artifactory-du) - estimate file space usage. Summarize disk usage in JFrog Artifactory of the set of FILEs, recursively for directories.
 - [artifacotyr-cleanup-rules](https://github.com/devopshq/artifactory-du/issues/2) - python-script for Artifactory intelligence cleanup rules with config.
-
-
-

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -274,10 +274,12 @@ class ArtifactoryAccessorTest(unittest.TestCase):
                 "size" : "26776462",
                 "checksums" : {
                     "sha1" : "fc6c9e8ba6eaca4fa97868ac900570282133c095",
+                    "sha256" : "fc6c9e8ba6eaca4fa97868ac900570282133c095fc6c9e8ba6eaca4fa97868ac900570282133c095",
                     "md5" : "2af7d54a09e9c36d704cb3a2de28aff3"
                 },
                 "originalChecksums" : {
                     "sha1" : "fc6c9e8ba6eaca4fa97868ac900570282133c095",
+                    "sha256" : "fc6c9e8ba6eaca4fa97868ac900570282133c095fc6c9e8ba6eaca4fa97868ac900570282133c095",
                     "md5" : "2af7d54a09e9c36d704cb3a2de28aff3"
                 },
                 "uri" : "http://artifactory.local/artifactory/api/storage/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz"
@@ -326,6 +328,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
         self.assertEqual(s.mime_type, "application/octet-stream")
         self.assertEqual(s.size, 26776462)
         self.assertEqual(s.sha1, "fc6c9e8ba6eaca4fa97868ac900570282133c095")
+        self.assertEqual(s.sha256, "fc6c9e8ba6eaca4fa97868ac900570282133c095fc6c9e8ba6eaca4fa97868ac900570282133c095")
         self.assertEqual(s.md5, "2af7d54a09e9c36d704cb3a2de28aff3")
         self.assertEqual(s.is_dir, False)
 
@@ -342,6 +345,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
         self.assertEqual(s.mime_type, None)
         self.assertEqual(s.size, 0)
         self.assertEqual(s.sha1, None)
+        self.assertEqual(s.sha256, None)
         self.assertEqual(s.md5, None)
         self.assertEqual(s.is_dir, True)
 


### PR DESCRIPTION
Because SHA-1 is to be considered like MD5, ie, vulnerable and not reliable enough. Preference should go to SHA-256 natively supported by Artifactory since v5.5+.

Thanks