### PR TITLE
0.4.112 (July 9, 2019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Python interface library for Jfrog Artifactory #
 
+
 [![docs](https://img.shields.io/readthedocs/pip.svg)](https://devopshq.github.io/artifactory/)[![dohq-artifactory build Status](https://travis-ci.org/devopshq/artifactory.svg?branch=master)](https://travis-ci.org/devopshq/artifactory) [![dohq-artifactory code quality](https://api.codacy.com/project/badge/Grade/ce32469db9d948bcb56d50532e0c0005)](https://www.codacy.com/app/tim55667757/artifactory/dashboard) [![dohq-artifactory on PyPI](https://img.shields.io/pypi/v/dohq-artifactory.svg)](https://pypi.python.org/pypi/dohq-artifactory) [![dohq-artifactory license](https://img.shields.io/pypi/l/dohq-artifactory.svg)](https://github.com/devopshq/artifactory/blob/master/LICENSE)
 
 This module is intended to serve as a logical descendant of [pathlib](https://docs.python.org/3/library/pathlib.html), a Python 3 module for object-oriented path manipulations. As such, it implements everything as closely as possible to the origin with few exceptions, such as stat().
+
+![](https://img.shields.io/badge/status-supported-green.svg)`dohq-artifactory` is a live python package for Jfrog Artifactory. It was forked from outdated [parallels/artifactory](https://github.com/parallels/artifactory) and support all functional from the original package.
 
 # Tables of Contents
 - [Install](#install)

--- a/artifactory.py
+++ b/artifactory.py
@@ -558,6 +558,8 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if 'children' in jsn:
             children = [child['uri'][1:] for child in jsn['children']]
 
+        checksums = jsn.get('checksums', {})
+
         stat = ArtifactoryFileStat(
             ctime=dateutil.parser.parse(jsn['created']),
             mtime=dateutil.parser.parse(jsn['lastModified']),
@@ -565,9 +567,9 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             modified_by=jsn.get('modifiedBy', None),
             mime_type=jsn.get('mimeType', None),
             size=int(jsn.get('size', '0')),
-            sha1=jsn.get('checksums', {'sha1': None})['sha1'],
-            sha256=jsn.get('checksums', {'sha256': None})['sha256'],
-            md5=jsn.get('checksums', {'md5': None})['md5'],
+            sha1=checksums.get('sha1', None),
+            sha256=checksums.get('sha256', None),
+            md5=checksums.get('md5', None),
             is_dir=is_dir,
             children=children)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-__version__ = '0.4.109'  # identify main version of dohq-artifactory
+__version__ = '0.4.110'  # identify main version of dohq-artifactory
 
 print("dohq-artifactory build version = {}".format(__version__))
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-__version__ = '0.4.110'  # identify main version of dohq-artifactory
+__version__ = '0.4.111'  # identify main version of dohq-artifactory
 
 print("dohq-artifactory build version = {}".format(__version__))
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-__version__ = '0.4.111'  # identify main version of dohq-artifactory
+__version__ = '0.4.112'  # identify main version of dohq-artifactory
 
 print("dohq-artifactory build version = {}".format(__version__))
 

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -349,6 +349,48 @@ class ArtifactoryAccessorTest(unittest.TestCase):
         self.assertEqual(s.md5, None)
         self.assertEqual(s.is_dir, True)
 
+    def test_stat_no_sha256(self):
+        a = self.cls()
+        P = artifactory.ArtifactoryPath
+
+        # Regular File
+        p = P("http://artifactory.local/artifactory/api/storage/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz")
+        file_stat = """
+            {
+                "repo" : "ext-release-local",
+                "path" : "/org/company/tool/1.0/tool-1.0.tar.gz",
+                "created" : "2014-02-24T21:20:59.999+04:00",
+                "createdBy" : "someuser",
+                "lastModified" : "2014-02-24T21:20:36.000+04:00",
+                "modifiedBy" : "anotheruser",
+                "lastUpdated" : "2014-02-24T21:20:36.000+04:00",
+                "downloadUri" : "http://artifactory.local/artifactory/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz",
+                "mimeType" : "application/octet-stream",
+                "size" : "26776462",
+                "checksums" : {
+                    "sha1" : "fc6c9e8ba6eaca4fa97868ac900570282133c095",
+                    "md5" : "2af7d54a09e9c36d704cb3a2de28aff3"
+                },
+                "originalChecksums" : {
+                    "sha1" : "fc6c9e8ba6eaca4fa97868ac900570282133c095",
+                    "md5" : "2af7d54a09e9c36d704cb3a2de28aff3"
+                },
+                "uri" : "http://artifactory.local/artifactory/api/storage/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz"
+            }
+        """
+
+        a.rest_get = MM(return_value=(file_stat, 200))
+
+        s = a.stat(p)
+        self.assertEqual(s.ctime, dateutil.parser.parse("2014-02-24T21:20:59.999+04:00"))
+        self.assertEqual(s.mtime, dateutil.parser.parse("2014-02-24T21:20:36.000+04:00"))
+        self.assertEqual(s.created_by, "someuser")
+        self.assertEqual(s.modified_by, "anotheruser")
+        self.assertEqual(s.mime_type, "application/octet-stream")
+        self.assertEqual(s.size, 26776462)
+        self.assertEqual(s.sha1, "fc6c9e8ba6eaca4fa97868ac900570282133c095")
+        self.assertEqual(s.sha256, None)
+
     def test_listdir(self):
         a = self.cls()
         P = artifactory.ArtifactoryPath


### PR DESCRIPTION
Fix #66, remove pathlib for python<3.4