### PR TITLE
Don't require pathlib on Python >= 3.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pathlib
+pathlib; python_version<"3.4"
 requests
 python-dateutil
 pytest

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     url='https://devopshq.github.io/artifactory/',
     download_url='https://github.com/devopshq/artifactory',
     install_requires=[
-        'pathlib',
+        'pathlib ; python_version<"3.4"',
         'requests',
         'python-dateutil'
     ],


### PR DESCRIPTION
We don't need pathlib on Python >= 3.4. In fact, the version that is on pypi is no longer maintained so probably shouldn't be used.

Could also consider dropping support for Python < 3.4 completely (these versions are no longer maintained).