### PR TITLE
Improvements and test coverage over splitroot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Whether or not you specify ```http://``` or ```https://```, the prefix is not es
 
 
 # Contribute
-[About contribute](docs/CONTRIBUTE.md)
+[About contributing and testing](docs/CONTRIBUTE.md)
 
 # Advertising
 - [artifactory-du](https://github.com/devopshq/artifactory-du) - estimate file space usage. Summarize disk usage in JFrog Artifactory of the set of FILEs, recursively for directories.

--- a/artifactory.py
+++ b/artifactory.py
@@ -385,7 +385,7 @@ class _ArtifactoryFlavour(pathlib._Flavour):
                 parts = part.split(mark)
             else:
                 path = self._get_path(part)
-                drv = part.rsplit(path, 1)[0]
+                drv = part.rpartition(path)[0]
                 path_parts = path.strip(sep).split(sep)
                 root = sep + path_parts[0] + sep
                 rest = sep.join(path_parts[1:])

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -2,7 +2,7 @@
 - [Development](#development)
 - [Tests](#tests)
 
-We will be grateful to see you in the ranks of the contributors! We have [some issue](https://github.com/devopshq/artifactory/issues).
+We will be grateful to see you in the ranks of the contributors! We have [some issues](https://github.com/devopshq/artifactory/issues).
 
 ## Development
 Development takes place on GitHub, where the git-flow branch structure is used:
@@ -12,20 +12,20 @@ Development takes place on GitHub, where the git-flow branch structure is used:
 * ``feature/XXX`` - feature branches are used for development of new features before they are merged to ``develop``.
 
 ## Tests
-We have 2 type of test
+We have two type of test.
 
 ### Unit
-You can write unit-test. Please, do it. How to run unit-tests:
+If you can write unit tests, please do so. How to run them:
 ```bash
 python -mpytest -munit
 ```
 
 ### Integration
-For integration test you need have **TEST** local Artifactory instance, which is installed useing one of methods:
+For integration test you need have **TEST** local Artifactory instance, which is installed using one of methods:
 1. https://github.com/JFrogDev/artifactory-user-plugins-devenv
 2. or https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory
 
-Set you Artifactory instances uri\admin-username\admin-password to `tests\test.cfg` file before run test
+Set your Artifactory instances uri\admin-username\admin-password to `tests\test.cfg` file before running the tests
 
 ```bash
 python -mpytest -mintegration

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -156,6 +156,8 @@ class ArtifactoryFlavorTest(unittest.TestCase):
               ('https://artifacts.example.com', '/root/', 'parts'))
         check("https://artifacts.example.com/root/artifactory/parts/",
               ('https://artifacts.example.com', '/root/', 'artifactory/parts'))
+        check("https://artifacts.example.com/artifacts",
+              ('https://artifacts.example.com', '/artifacts/', ''))
 
     def test_splitroot_custom_root(self):
         check = self._check_splitroot

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -125,8 +125,8 @@ class ArtifactoryFlavorTest(unittest.TestCase):
         #check("https://a/b/?", ("https://a", "/b/", "?"))
 
     def test_splitroot_custom_drv(self):
-        """
-        https://github.com/devopshq/artifactory/issues/31
+        """https://github.com/devopshq/artifactory/issues/31 and
+        https://github.com/devopshq/artifactory/issues/108
         """
         check = self._check_splitroot
 


### PR DESCRIPTION
-Test for #108. Fails on master branch as it should. Works on develop branch.
-rpartition should be quicker than rsplit. Improves #109 