### PR TITLE
Add support for remote repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This module is intended to serve as a logical descendant of [pathlib](https://do
         - [ Internal](#internal)
         - [ GroupLDAP](#groupldap)
     - [RepositoryLocal](#repositorylocal)
-    - [RepositoryVirtual](#virtualrepository)
+    - [RepositoryVirtual](#repositoryvirtual)
+    - [RepositoryRemote](#repositoryremote)
     - [PermissionTarget](#permissiontarget)
     - [Common](#common)
 - [FAQ](docs/FAQ.md)
@@ -410,6 +411,24 @@ if repo is None:
 repo.read()
 
 local_repos = repo.repositories # return List<RepositiryLocal>
+
+repo.delete()
+```
+
+## RepositoryRemote
+```python
+# Find
+from dohq_artifactory import RepositoryRemote
+repo = artifactory_.find_repository_virtual('pypi.all')
+
+# Create
+if repo is None:
+    # or RepositoryRemote.PYPI, RepositoryRemote.NUGET, etc
+    repo = RepositoryRemote(artifactory_, 'pypi.all', url='https://files.pythonhosted.org', packageType=RepositoryVirtual.PYPI)
+    repo.create()
+
+# You can re-read from Artifactory
+repo.read()
 
 repo.delete()
 ```

--- a/artifactory.py
+++ b/artifactory.py
@@ -38,7 +38,7 @@ import dateutil.parser
 import requests
 import urllib.parse
 
-from dohq_artifactory.admin import User, Group, RepositoryLocal, PermissionTarget, RepositoryVirtual
+from dohq_artifactory.admin import User, Group, RepositoryLocal, PermissionTarget, RepositoryVirtual, RepositoryRemote
 from dohq_artifactory.auth import XJFrogArtApiAuth
 
 try:
@@ -1465,6 +1465,12 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
     def find_repository_virtual(self, name):
         obj = RepositoryVirtual(self, name, packageType=None)
+        if obj.read():
+            return obj
+        return None
+
+    def find_repository_remote(self, name):
+        obj = RepositoryRemote(self, name, packageType=None)
         if obj.read():
             return obj
         return None

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -410,6 +410,63 @@ class RepositoryVirtual(AdminObject):
         return [self._artifactory.find_repository_local(x) for x in self._repositories]
 
 
+class RepositoryRemote(Repository):
+    _uri = 'repositories'
+
+    def __init__(self, artifactory, name, url=None, packageType=Repository.GENERIC, dockerApiVersion=Repository.V1):
+        super(RepositoryRemote, self).__init__(artifactory)
+        self.name = name
+        self.description = ''
+        self.packageType = packageType
+        self.repoLayoutRef = 'maven-2-default'
+        self.archiveBrowsingEnabled = True
+        self.dockerApiVersion = dockerApiVersion
+        self.url = url
+
+    def _create_json(self):
+        """
+        JSON Documentation: https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON
+        """
+        data_json = {
+            "rclass": "remote",
+            "key": self.name,
+            "description": self.description,
+            "packageType": self.packageType,
+            "notes": "",
+            "includesPattern": "**/*",
+            "excludesPattern": "",
+            "repoLayoutRef": self.repoLayoutRef,
+            "dockerApiVersion": self.dockerApiVersion,
+            "checksumPolicyType": "client-checksums",
+            "handleReleases": True,
+            "handleSnapshots": True,
+            "maxUniqueSnapshots": 0,
+            "snapshotVersionBehavior": "unique",
+            "suppressPomConsistencyChecks": True,
+            "blackedOut": False,
+            "propertySets": [],
+            "archiveBrowsingEnabled": self.archiveBrowsingEnabled,
+            "yumRootDepth": 0,
+            "url": self.url,
+            "debianTrivialLayout" : False,
+            "maxUniqueTags": 0,
+            "xrayIndex" : False,
+            "calculateYumMetadata" : False,
+            "enableFileListsIndexing" : False,
+            "optionalIndexCompressionFormats" : ["bz2", "lzma", "xz"],
+            "downloadRedirect" : False
+        }
+        return data_json
+
+    def _read_response(self, response):
+        """
+        JSON Documentation: https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON
+        """
+        self.name = response['key']
+        self.description = response.get('description')
+        self.layoutName = response.get('repoLayoutRef')
+        self.archiveBrowsingEnabled = response.get('archiveBrowsingEnabled')
+
 class PermissionTarget(AdminObject):
     _uri = 'security/permissions'
 

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -448,13 +448,13 @@ class RepositoryRemote(Repository):
             "archiveBrowsingEnabled": self.archiveBrowsingEnabled,
             "yumRootDepth": 0,
             "url": self.url,
-            "debianTrivialLayout" : False,
+            "debianTrivialLayout": False,
             "maxUniqueTags": 0,
-            "xrayIndex" : False,
-            "calculateYumMetadata" : False,
-            "enableFileListsIndexing" : False,
-            "optionalIndexCompressionFormats" : ["bz2", "lzma", "xz"],
-            "downloadRedirect" : False
+            "xrayIndex": False,
+            "calculateYumMetadata": False,
+            "enableFileListsIndexing": False,
+            "optionalIndexCompressionFormats": ["bz2", "lzma", "xz"],
+            "downloadRedirect": False
         }
         return data_json
 
@@ -466,6 +466,7 @@ class RepositoryRemote(Repository):
         self.description = response.get('description')
         self.layoutName = response.get('repoLayoutRef')
         self.archiveBrowsingEnabled = response.get('archiveBrowsingEnabled')
+
 
 class PermissionTarget(AdminObject):
     _uri = 'security/permissions'


### PR DESCRIPTION
This PR adds support for managing [remote repositories](https://jfrog.com/knowledge-base/what-is-a-remote-repository-and-how-does-it-work/) and associated docs.