### PR TITLE
fix get_stat_json using wrong url

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -583,7 +583,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         """
         url = "/".join(
             [
-                pathobj.drive,
+                pathobj.drive.rstrip("/"),
                 "api/storage",
                 str(pathobj.relative_to(pathobj.drive)).strip("/"),
             ]


### PR DESCRIPTION
The artifact upload process fails because when we create the
Artifactory Storage API request we duplicate the / between artifactory
and api.

Let's say we're trying to upload an artifact to
http://my-artifactory/artifactory/upload-dest .
When we reach get_stat_json and process the url, instead of getting
http://my-artifactory/artifactory/api/storage/upload-dest
we get http://my-artifactory/artifactory//api/storage/upload-dest

This in turn returns a 500 Repo key cannot be empty error and fails
the upload.

Fixes #126 