### PR TITLE
Fix the ArtifactoryFlavour for python 3.7+

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -24,11 +24,13 @@ pure paths can be used.
 """
 import collections
 import errno
+import fnmatch
 import hashlib
 import json
 import logging
 import os
 import pathlib
+import re
 import sys
 import urllib.parse
 from itertools import islice
@@ -349,6 +351,9 @@ class _ArtifactoryFlavour(pathlib._Flavour):
 
     def _get_base_url(self, url):
         return get_global_base_url(url)
+
+    def compile_pattern(self, pattern):
+        return re.compile(fnmatch.translate(pattern), re.IGNORECASE).fullmatch
 
     def parse_parts(self, parts):
         drv, root, parsed = super(_ArtifactoryFlavour, self).parse_parts(parts)


### PR DESCRIPTION
Hello, 

From python 3.7 onward, clients of the pathlib._Flavour object expect being able to call a `compile_pattern` method as we can see on the following backtrace:

```
  File "/usr/local/lib/python3.8/pathlib.py", line 1132, in glob
    selector = _make_selector(tuple(pattern_parts), self._flavour)
  File "/usr/local/lib/python3.8/pathlib.py", line 471, in _make_selector
    return cls(pat, child_parts, flavour)
  File "/usr/local/lib/python3.8/pathlib.py", line 554, in __init__
    _Selector.__init__(self, child_parts, flavour)
  File "/usr/local/lib/python3.8/pathlib.py", line 484, in __init__
    self.successor = _make_selector(child_parts, flavour)
  File "/usr/local/lib/python3.8/pathlib.py", line 471, in _make_selector
    return cls(pat, child_parts, flavour)
  File "/usr/local/lib/python3.8/pathlib.py", line 527, in __init__
    self.match = flavour.compile_pattern(pat)
AttributeError: '_ArtifactoryFlavour' object has no attribute 'compile_pattern'
```
I just added a basic implementation (which is exactly what is done in Python 3.7 code base see commit 175abccbbfc)