### PR TITLE
Sometimes user doesn't have an email

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -193,7 +193,7 @@ class User(AdminObject):
         """
         # self.password = ''  # never returned
         self.name = response["name"]
-        self.email = response["email"]
+        self.email = response.get("email", None)
         self.admin = response["admin"]
         self.profileUpdatable = response["profileUpdatable"]
         self.disableUIAccess = response["disableUIAccess"]


### PR DESCRIPTION
Sometimes user doesn't have an email. For example, *anonymous*:
```json
{
  "name" : "anonymous",
  "admin" : false,
  "profileUpdatable" : false,
  "internalPasswordDisabled" : false,
  "lastLoggedIn" : "2020-02-25T14:30:28.411Z",
  "lastLoggedInMillis" : 0,
  "realm" : "internal",
  "offlineMode" : false,
  "disableUIAccess" : false
}
```

`user = ap.find_user("anonymous")` cause `KeyError: 'email'` exception.