### PR TITLE
fix mismatched attrib in RepositoryLocal/Remote

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -377,7 +377,7 @@ class RepositoryLocal(Repository):
         """
         self.name = response["key"]
         self.description = response.get("description")
-        self.layoutName = response.get("repoLayoutRef")
+        self.repoLayoutRef = response.get("repoLayoutRef")
         self.archiveBrowsingEnabled = response.get("archiveBrowsingEnabled")
 
 
@@ -511,7 +511,7 @@ class RepositoryRemote(Repository):
         """
         self.name = response["key"]
         self.description = response.get("description")
-        self.layoutName = response.get("repoLayoutRef")
+        self.repoLayoutRef = response.get("repoLayoutRef")
         self.archiveBrowsingEnabled = response.get("archiveBrowsingEnabled")
 
 


### PR DESCRIPTION
Populate repoLayoutRef attribute in _read_response() for
RepositoryLocal and RepositoryRemote in order to get the
correct value instead of the default one.

Fixes #146 