### PR TITLE
enhance requests errors

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1619,7 +1619,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         :param lazy: `True` if we don't need anything except object's name
         """
-        return self._get_all(url="/api/security/groups", key="name", cls=Group, lazy=lazy)
+        return self._get_all(
+            url="/api/security/groups", key="name", cls=Group, lazy=lazy
+        )
 
     def get_repositories(self, lazy=False):
         """
@@ -1627,7 +1629,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         :param lazy: `True` if we don't need anything except object's name
         """
-        return self._get_all(url="/api/repositories", key="key", cls=Repository, lazy=lazy)
+        return self._get_all(
+            url="/api/repositories", key="key", cls=Repository, lazy=lazy
+        )
 
     def get_permissions(self, lazy=False):
         """
@@ -1635,7 +1639,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         :param lazy: `True` if we don't need anything except object's name
         """
-        return self._get_all(url="/api/security/permissions", key="name", cls=PermissionTarget, lazy=lazy)
+        return self._get_all(
+            url="/api/security/permissions", key="name", cls=PermissionTarget, lazy=lazy
+        )
 
 
 class ArtifactorySaaSPath(ArtifactoryPath):

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import requests
 import string
 import sys
 import time
@@ -93,9 +94,14 @@ class AdminObject(object):
             headers={"Content-Type": "application/json"},
             auth=self._auth,
         )
-        r.raise_for_status()
-        rest_delay()
-        self.read()
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Response text: {}".format(e.resonse.text))
+            raise SystemExit(e)
+        else:
+            rest_delay()
+            self.read()
 
     def _read_response(self, response):
         """
@@ -124,11 +130,16 @@ class AdminObject(object):
             return False
         else:
             logging.debug("{x.__class__.__name__} [{x.name}] exist".format(x=self))
-            r.raise_for_status()
-            response = r.json()
-            self.raw = response
-            self._read_response(response)
-            return True
+            try:
+                r.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                print("Response text: {}".format(e.resonse.text))
+                raise SystemExit(e)
+            else:
+                response = r.json()
+                self.raw = response
+                self._read_response(response)
+                return True
 
     def update(self):
         """
@@ -148,8 +159,13 @@ class AdminObject(object):
             uri=self._uri, x=self
         )
         r = self._session.delete(request_url, auth=self._auth,)
-        r.raise_for_status()
-        rest_delay()
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Response text: {}".format(e.resonse.text))
+            raise SystemExit(e)
+        else:
+            rest_delay()
 
 
 class User(AdminObject):
@@ -218,9 +234,14 @@ class User(AdminObject):
         logging.debug("User get encrypted password [{x.name}]".format(x=self))
         request_url = self._artifactory.drive + "/api/security/encryptedPassword"
         r = self._session.get(request_url, auth=(self.name, self.password),)
-        r.raise_for_status()
-        encryptedPassword = r.text
-        return encryptedPassword
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Response text: {}".format(e.resonse.text))
+            raise SystemExit(e)
+        else:
+            encryptedPassword = r.text
+            return encryptedPassword
 
     @property
     def lastLoggedIn(self):

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -17,12 +17,9 @@ def raise_errors(r):
         r.raise_for_status()
     except requests.HTTPError as e:
         if e.response.status_code >= 400:
-            logging.warning("Artifactory returned an error. Response text: {}".format(e.resonse.text))
-            raise ArtifactoryException
+            raise ArtifactoryException(e.response.text)
         else:
             raise e
-    else:
-        pass
 
 
 def _old_function_for_secret(pw_len=16):

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -1,9 +1,10 @@
 import logging
 import random
-import requests
 import string
 import sys
 import time
+
+import requests
 
 from dohq_artifactory.exception import ArtifactoryException
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from artifactory import ArtifactoryPath
 import os
 import sys
 
 import pytest
 
+from artifactory import ArtifactoryPath
 from dohq_artifactory import Group
 from dohq_artifactory import PermissionTarget
 from dohq_artifactory import RepositoryLocal
@@ -17,12 +17,8 @@ else:
 
 
 def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "unit: unit tests"
-    )
-    config.addinivalue_line(
-        "markers", "integration: integration tests"
-    )
+    config.addinivalue_line("markers", "unit: unit tests")
+    config.addinivalue_line("markers", "integration: integration tests")
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import unittest
+import mock
+
+import requests
+
+from dohq_artifactory.admin import raise_errors
+from dohq_artifactory.exception import ArtifactoryException
+
+
+class UtilTest(unittest.TestCase):
+    def test_raise_errors(self):
+        r = requests.Response()
+        r.status_code = 400
+        type(r).text = mock.PropertyMock(return_value='asd')
+        with self.assertRaises(ArtifactoryException) as cm:
+            raise_errors(r)
+        self.assertEqual('asd', str(cm.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
-import mock
 
+import mock
 import requests
 
 from dohq_artifactory.admin import raise_errors
@@ -12,11 +12,11 @@ class UtilTest(unittest.TestCase):
     def test_raise_errors(self):
         r = requests.Response()
         r.status_code = 400
-        type(r).text = mock.PropertyMock(return_value='asd')
+        type(r).text = mock.PropertyMock(return_value="asd")
         with self.assertRaises(ArtifactoryException) as cm:
             raise_errors(r)
-        self.assertEqual('asd', str(cm.exception))
+        self.assertEqual("asd", str(cm.exception))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently, because we're only using the requests
raise_for_status() we are missing out on potential relevant
information sent by the Artifactory server in the response
message.

In order to better handle this also print the error message
returned by the server before raising the error itself.

Fixes #145 