### PR TITLE
Fixed Repository Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ if repo is None:
 # You can re-read from Artifactory
 repo.read()
 
-local_repos = repo.repositories  # return List<RepositiryLocal>
+local_repos = repo.repositories  # return List<RepositoryLocal>
 
 repo.delete()
 ```

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -468,7 +468,7 @@ class RepositoryVirtual(AdminObject):
         rclass = response["rclass"]
         if rclass != "virtual":
             raise ArtifactoryException(
-                "Repositiry '{}' have '{}', but expect 'virtual'".format(
+                "Repository '{}' have '{}', but expect 'virtual'".format(
                     self.name, rclass
                 )
             )


### PR DESCRIPTION
Repository was misspelled in two places and I just wanted to have it fixed.