### PR TITLE
allow setting profile_updatable when creating user

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -185,7 +185,7 @@ class AdminObject(object):
 class User(AdminObject):
     _uri = "security/users"
 
-    def __init__(self, artifactory, name, email=None, password=None, disable_ui=False):
+    def __init__(self, artifactory, name, email=None, password=None, disable_ui=False, profile_updatable=True):
         super(User, self).__init__(artifactory)
 
         self.name = name
@@ -193,7 +193,7 @@ class User(AdminObject):
 
         self.password = password
         self.admin = False
-        self.profileUpdatable = True
+        self.profileUpdatable = profile_updatable
         self.disableUIAccess = disable_ui
         self.internalPasswordDisabled = False
         self._groups = []

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -19,7 +19,7 @@ class TestUser:
             name=user_name,
             email="test_user@example.com",
             password="password",
-            profile_updatable=True
+            profile_updatable=True,
         )
 
         # CREATE

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -19,6 +19,7 @@ class TestUser:
             name=user_name,
             email="test_user@example.com",
             password="password",
+            profile_updatable=True
         )
 
         # CREATE


### PR DESCRIPTION
When creating a new user enable toggling the profile_updatable
flag from True to False.

Fixes #178 