### PR TITLE
Fill repo packageType

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1597,19 +1597,19 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         return None
 
     def find_repository_local(self, name):
-        obj = RepositoryLocal(self, name, packageType=None)
+        obj = RepositoryLocal(self, name)
         if obj.read():
             return obj
         return None
 
     def find_repository_virtual(self, name):
-        obj = RepositoryVirtual(self, name, packageType=None)
+        obj = RepositoryVirtual(self, name)
         if obj.read():
             return obj
         return None
 
     def find_repository_remote(self, name):
-        obj = RepositoryRemote(self, name, packageType=None)
+        obj = RepositoryRemote(self, name)
         if obj.read():
             return obj
         return None

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -427,6 +427,7 @@ class RepositoryLocal(Repository):
         """
         self.name = response["key"]
         self.description = response.get("description")
+        self.packageType = response.get("packageType")
         self.repoLayoutRef = response.get("repoLayoutRef")
         self.archiveBrowsingEnabled = response.get("archiveBrowsingEnabled")
 
@@ -491,9 +492,9 @@ class RepositoryVirtual(AdminObject):
             )
 
         self.name = response["key"]
-        self.description = response["description"]
-        self.packageType = response["packageType"]
-        self._repositories = response["repositories"]
+        self.description = response.get("description")
+        self.packageType = response.get("packageType")
+        self._repositories = response.get("repositories")
 
     @property
     def repositories(self):
@@ -561,6 +562,7 @@ class RepositoryRemote(Repository):
         """
         self.name = response["key"]
         self.description = response.get("description")
+        self.packageType = response.get("packageType")
         self.repoLayoutRef = response.get("repoLayoutRef")
         self.archiveBrowsingEnabled = response.get("archiveBrowsingEnabled")
 


### PR DESCRIPTION
After creating and reading any repository you still see packageType is Generic (if creating via constructor) or None (if creating via ArtifactoryPath.find_repository_*). The real value is saved into .raw attribute, and that's not convenient.
Let'f fill this field up in .read() method.