### PR TITLE
Fix filling up `.url` attribute of RepositoryRemote

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -563,6 +563,7 @@ class RepositoryRemote(Repository):
         self.description = response.get("description")
         self.repoLayoutRef = response.get("repoLayoutRef")
         self.archiveBrowsingEnabled = response.get("archiveBrowsingEnabled")
+        self.url = response.get("url")
 
 
 class PermissionTarget(AdminObject):


### PR DESCRIPTION
This should fix https://github.com/devopshq/artifactory/issues/164