### PR TITLE
Add __str__ and __repr__ for AdminObject

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -75,6 +75,12 @@ class AdminObject(object):
         self._auth = self._artifactory.auth
         self._session = self._artifactory.session
 
+    def __repr__(self):
+        return "<{self.__class__.__name__} {self.name}>".format(self=self)
+
+    def __str__(self):
+        return self.name
+
     def _create_json(self):
         """
         Function prepare JSON which send for create or update event


### PR DESCRIPTION
This allows to see in Python REPL
```
<User my_name>
<RepositoryLocal some_repo>
```

Instead of ugly names
```
<dohq_artifactory.admin.User object at 0xfe1421bc>
<dohq_artifactory.admin.RepositoryLocal object at 0x12bce980>
```