### PR TITLE
allow deploying artifacts from archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ path.mkdir()
 
 path.deploy_file("./myapp-1.0.tar.gz")
 ```
+
+Deploy artifacts from archive: this will automatically extract the contents of the archive on the server preserving the archive's paths
+
+```python
+from artifactory import ArtifactoryPath
+
+path = ArtifactoryPath(
+    "http://my-artifactory/artifactory/libs-snapshot-local/myapp/1.0"
+)
+path.mkdir()
+
+path.deploy_file("./myapp-1.0.tar.gz", explode_archive=True)
+```
+
 Deploy a debian package ```myapp-1.0.deb```
 
 ```python

--- a/artifactory.py
+++ b/artifactory.py
@@ -912,7 +912,16 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         return raw
 
-    def deploy(self, pathobj, fobj, md5=None, sha1=None, sha256=None, parameters=None):
+    def deploy(
+        self,
+        pathobj,
+        fobj,
+        md5=None,
+        sha1=None,
+        sha256=None,
+        parameters=None,
+        explode_archive=None,
+    ):
         """
         Uploads a given file-like object
         HTTP chunked encoding will be attempted
@@ -933,6 +942,8 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             headers["X-Checksum-Sha1"] = sha1
         if sha256:
             headers["X-Checksum-Sha256"] = sha256
+        if explode_archive:
+            headers["X-Explode-Archive"] = "true"
 
         text, code = self.rest_put_stream(
             url,
@@ -1479,16 +1490,36 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         """
         raise NotImplementedError()
 
-    def deploy(self, fobj, md5=None, sha1=None, sha256=None, parameters={}):
+    def deploy(
+        self,
+        fobj,
+        md5=None,
+        sha1=None,
+        sha256=None,
+        parameters={},
+        explode_archive=None,
+    ):
         """
         Upload the given file object to this path
         """
         return self._accessor.deploy(
-            self, fobj, md5=md5, sha1=sha1, sha256=sha256, parameters=parameters
+            self,
+            fobj,
+            md5=md5,
+            sha1=sha1,
+            sha256=sha256,
+            parameters=parameters,
+            explode_archive=explode_archive,
         )
 
     def deploy_file(
-        self, file_name, calc_md5=True, calc_sha1=True, calc_sha256=True, parameters={}
+        self,
+        file_name,
+        calc_md5=True,
+        calc_sha1=True,
+        calc_sha256=True,
+        parameters={},
+        explode_archive=False,
     ):
         """
         Upload the given file to this path
@@ -1504,7 +1535,12 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         with open(file_name, "rb") as fobj:
             target.deploy(
-                fobj, md5=md5, sha1=sha1, sha256=sha256, parameters=parameters
+                fobj,
+                md5=md5,
+                sha1=sha1,
+                sha256=sha256,
+                parameters=parameters,
+                explode_archive=explode_archive,
             )
 
     def deploy_deb(


### PR DESCRIPTION
Artifactory Pro and above offer the option to deploy an
archive containing multiple artifacts and automatically
have it extracted at the specified destination while
maintaining the archive's file structure [1].

[1] https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-DeployArtifactsfromArchive

Fixes #214 