### PR TITLE
Added docker image promotion api

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This module is intended to serve as a logical descendant of [pathlib](https://do
   * [Artifact properties](#artifact-properties)
   * [Artifactory Query Language](#artifactory-query-language)
   * [FileStat](#filestat)
+  * [Promote Docker image](#promote-docker-image)
 - [Admin area](#admin-area)
   * [User](#user)
   * [Group](#group)
@@ -395,6 +396,16 @@ print(stat.sha256)
 print(stat.ctime)
 print(stat.is_dir)
 print(stat.size)
+```
+
+## Promote Docker image
+Promotes a Docker image in a registry to another registry.
+```
+from artifactory import ArtifactoryPath
+
+path = ArtifactoryPath("http://example.com/artifactory")
+
+path.promote_docker_image("docker-staging", "docker-prod", "my-application", "0.5.1")
 ```
 
 # Admin area

--- a/artifactory.py
+++ b/artifactory.py
@@ -1708,16 +1708,13 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         promote_url = "{}/api/docker/{}/v2/promote".format(
             self.drive.rstrip("/"), source_repo
         )
-        promote_data = json.dumps(
-            {
-                "targetRepo": target_repo,
-                "dockerRepository": docker_repo,
-                "tag": tag,
-                "copy": copy,
-            }
-        )
-        headers = {"Content-Type": "application/json"}
-        r = self.session.post(promote_url, data=promote_data, headers=headers)
+        promote_data = {
+            "targetRepo": target_repo,
+            "dockerRepository": docker_repo,
+            "tag": tag,
+            "copy": copy,
+        }
+        r = self.session.post(promote_url, json=promote_data)
         if (
             r.status_code == 400
             and "Unsupported docker" in r.text

--- a/artifactory.py
+++ b/artifactory.py
@@ -1692,8 +1692,10 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
             timeout=self.timeout,
         )
         return obj
-    
-    def promote_docker_image(self, source_repo, target_repo, docker_repo, tag, copy=False):
+
+    def promote_docker_image(
+        self, source_repo, target_repo, docker_repo, tag, copy=False
+    ):
         """
         Promote Docker image from source repo to target repo
         :param source_repo: source repository
@@ -1703,20 +1705,27 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         :param copy (bool): whether to move the image or copy it
         :return:
         """
-        promote_url = "{}/api/docker/{}/v2/promote".format(self.drive.rstrip("/"), source_repo)
-        promote_data = json.dumps({
-            "targetRepo": target_repo,
-            "dockerRepository": docker_repo,
-            "tag": tag,
-            "copy": copy
-        })
-        headers = {
-            "Content-Type": "application/json"
-        }
+        promote_url = "{}/api/docker/{}/v2/promote".format(
+            self.drive.rstrip("/"), source_repo
+        )
+        promote_data = json.dumps(
+            {
+                "targetRepo": target_repo,
+                "dockerRepository": docker_repo,
+                "tag": tag,
+                "copy": copy,
+            }
+        )
+        headers = {"Content-Type": "application/json"}
         r = self.session.post(promote_url, data=promote_data, headers=headers)
-        if (r.status_code == 400 and "Unsupported docker" in r.text
-            or r.status_code == 403 and "No permission" in r.text
-            or r.status_code == 404 and "Unable to find" in r.text):
+        if (
+            r.status_code == 400
+            and "Unsupported docker" in r.text
+            or r.status_code == 403
+            and "No permission" in r.text
+            or r.status_code == 404
+            and "Unable to find" in r.text
+        ):
             raise ArtifactoryException(r.text)
         else:
             r.raise_for_status()


### PR DESCRIPTION
Usage example:
```
from artifactory import ArtifactoryPath

path = ArtifactoryPath("http://example.com/artifactory")
path.promote_docker_image("docker-staging", "docker-prod", "my-application", "0.5.1")
```
Promotes the image myapplciation:0.5.1 from staging registry to prod registry

