### PR TITLE
Fix small typo on method docs

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1629,7 +1629,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
     def copy(self, dst, suppress_layouts=False):
         """
-        Copy artifact from this path to destinaiton.
+        Copy artifact from this path to destination.
         If files are on the same instance of artifactory, lightweight (local)
         copying will be attempted.
 


### PR DESCRIPTION
Fixed typo in docs of `ArtifactoryPath.copy` method.