### PR TITLE
Support 'bytes' type parameter in 'writeto' method (ArtifactoryPath)

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1951,6 +1951,8 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         :param progress_func: Provide custom function to print output or suppress print by setting to None
         :return: None
         """
+        if isinstance(out, bytes):
+            out = out.decode()
         if isinstance(out, str) or isinstance(out, pathlib.Path):
             context = open(out, "wb")
         else:


### PR DESCRIPTION
Add `bytes` type support (as output file path) in `writeto` method in `ArtifactoryPath` class.

For example without this bytes/str conversion the following code snippet is failed:

**Code:**

```python
from artifactory import ArtifactoryPath

path = ArtifactoryPath(
    "https://arm.test.com/artifactory/repo/test_file.tgz",
    auth=("user", "password"),
)

path.writeto(b"test_file_local.tgz")
```

**Output:**

```
>>> python test.py 
Traceback (most recent call last):
  File "test.py", line 12, in <module>
    path.writeto(b"test_file_local.tgz")
  File "/home/my_user/venv3/lib/python3.6/site-packages/artifactory.py", line 1960, in writeto
    self._accessor.writeto(self, file, chunk_size, progress_func)
  File "/home/my_user/venv3/lib/python3.6/site-packages/artifactory.py", line 1178, in writeto
    file.write(chunk)
AttributeError: 'bytes' object has no attribute 'write'
```

Of course, with my change it works as expected.