### PR TITLE
beliaev/requests clean

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -637,7 +637,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             cert=cert,
             timeout=timeout,
         )
-        return res.text, res.status_code
+        return res
 
     @staticmethod
     def rest_put(
@@ -693,12 +693,20 @@ class _ArtifactoryAccessor(pathlib._Accessor):
     def rest_del(url, params=None, session=None, verify=True, cert=None, timeout=None):
         """
         Perform a DELETE request to url with requests.session
+        :param url: url
+        :param params: request parameters
+        :param session:
+        :param verify:
+        :param cert:
+        :param timeout:
+        :return: request response object
         """
         url = quote_url(url)
-        res = session.delete(
+        response = session.delete(
             url, params=params, verify=verify, cert=cert, timeout=timeout
         )
-        return res.text, res.status_code
+        response.raise_for_status()
+        return response
 
     @staticmethod
     def rest_put_stream(
@@ -864,21 +872,14 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         url = str(pathobj) + "/"
 
-        text, code = self.rest_del(
+        self.rest_del(
             url, session=pathobj.session, verify=pathobj.verify, cert=pathobj.cert
         )
 
-        if code not in (200, 202, 204):
-            raise RuntimeError("Failed to delete directory: '%s'" % text)
-
     def unlink(self, pathobj):
         """
-        Removes a file
+        Removes a file or folder
         """
-
-        # TODO: Why do we forbid remove folder?
-        # if stat.is_dir:
-        #     raise IsADirectoryError(1, "Operation not permitted: {!r}".format(pathobj))
 
         url = "/".join(
             [
@@ -886,16 +887,13 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                 str(pathobj.relative_to(pathobj.drive)).strip("/"),
             ]
         )
-        text, code = self.rest_del(
+        self.rest_del(
             url,
             session=pathobj.session,
             verify=pathobj.verify,
             cert=pathobj.cert,
             timeout=pathobj.timeout,
         )
-
-        if code not in (200, 202, 204):
-            raise FileNotFoundError("Failed to delete file: {} {!r}".format(code, text))
 
     def touch(self, pathobj):
         """
@@ -1085,7 +1083,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         params = "properties"
 
-        text, code = self.rest_get(
+        response = self.rest_get(
             url,
             params=params,
             session=pathobj.session,
@@ -1093,13 +1091,14 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             cert=pathobj.cert,
             timeout=pathobj.timeout,
         )
-
+        code = response.status_code
+        text = response.text
         if code == 404 and ("Unable to find item" in text or "Not Found" in text):
             raise OSError(2, "No such file or directory: '%s'" % url)
         if code == 404 and "No properties could be found" in text:
             return {}
-        if code != 200:
-            raise RuntimeError(text)
+
+        response.raise_for_status()
 
         return json.loads(text)["properties"]
 
@@ -1154,7 +1153,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if not recursive:
             params["recursive"] = "0"
 
-        text, code = self.rest_del(
+        self.rest_del(
             url,
             params=params,
             session=pathobj.session,
@@ -1162,11 +1161,6 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             cert=pathobj.cert,
             timeout=pathobj.timeout,
         )
-
-        if code == 404 and ("Unable to find item" in text or "Not Found" in text):
-            raise OSError(2, "No such file or directory: '%s'" % url)
-        if code != 204:
-            raise RuntimeError(text)
 
     def scandir(self, pathobj):
         return _ScandirIter((pathobj.joinpath(x) for x in self.listdir(pathobj)))

--- a/artifactory.py
+++ b/artifactory.py
@@ -627,9 +627,17 @@ class _ArtifactoryAccessor(pathlib._Accessor):
     ):
         """
         Perform a GET request to url with requests.session
+        :param url:
+        :param params:
+        :param headers:
+        :param session:
+        :param verify:
+        :param cert:
+        :param timeout:
+        :return: response object
         """
         url = quote_url(url)
-        res = session.get(
+        response = session.get(
             url,
             params=params,
             headers=headers,
@@ -637,7 +645,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             cert=cert,
             timeout=timeout,
         )
-        return res
+        return response
 
     @staticmethod
     def rest_put(
@@ -754,17 +762,19 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             ]
         )
 
-        text, code = self.rest_get(
+        response = self.rest_get(
             url,
             session=pathobj.session,
             verify=pathobj.verify,
             cert=pathobj.cert,
             timeout=pathobj.timeout,
         )
+        code = response.status_code
+        text = response.text
         if code == 404 and ("Unable to find item" in text or "Not Found" in text):
             raise OSError(2, "No such file or directory: '%s'" % url)
-        if code != 200:
-            raise RuntimeError(text)
+
+        response.raise_for_status()
 
         return json.loads(text)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ flake8
 pre-commit
 tox
 PyJWT
+responses

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -584,6 +584,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
             url, f, headers={}, session=p.session, verify=True, cert=None, timeout=None
         )
 
+    @responses.activate
     def test_get_properties(self):
         properties = {
             "test": ["test_property"],
@@ -591,12 +592,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
             "time": ["2018-01-16 12:17:44.135143"],
         }
 
-        # Regular File
-        path = ArtifactoryPath(
-            "http://artifactory.local/artifactory/api/storage/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz"
-        )
-
-        path._accessor.rest_get = MM(return_value=(self.property_data, 200))
+        path = self._mock_properties_response()
 
         self.assertEqual(path.properties, properties)
 
@@ -614,7 +610,8 @@ class ArtifactoryAccessorTest(unittest.TestCase):
             "addthis": ["addthis"],
         }
 
-        self._set_properties(properties)
+        path = self._mock_properties_response()
+        path.properties = properties
 
         # Must delete only removed property
         # rest delete is a second call, use index 1
@@ -641,17 +638,17 @@ class ArtifactoryAccessorTest(unittest.TestCase):
             "removethis": ["removethis_property"],
         }
 
-        self._set_properties(properties)
+        path = self._mock_properties_response()
+        path.properties = properties
         self.assertEqual(
             responses.calls[1].request.params["properties"],
             "addthis=addthis;removethis=removethis_property;test=test_property;time=2018-01-16 12:17:44.135143",
         )
 
-    def _set_properties(self, properties):
+    def _mock_properties_response(self):
         """
         Function to mock responses on HTTP requests
-        :param properties: properties to assign on ArtifactoryPath
-        :return: None
+        :return: ArtifactoryPath instance object
         """
         # Regular File
         path = ArtifactoryPath(
@@ -688,7 +685,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
             status=204,
             body="",
         )
-        path.properties = properties
+        return path
 
 
 class ArtifactoryPathTest(unittest.TestCase):


### PR DESCRIPTION
done change in rest get and delete methods. This will raise for status and explicitly show an error, eg authentication, connection or whatever
will address #36

done change in tests.
use `responses` module, this allows to use a clean way to simulate request response instead of just mocking return value.
allows to unpack strings into json, see real codes, etc

Fixed artifactory path URLs in tests, they must not include `api/storage`