### PR TITLE
beliaev/archive fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ with path.archive(archive_type="zip", check_sum=False) as archive:
         out.write(archive.read())
 
 # download folder archive in chunks
-path.archive().writeto(output="my.zip", chunk_size=100 * 1024)
+path.archive().writeto(out="my.zip", chunk_size=100 * 1024)
 ```
 
 ## Uploading Artifacts ##


### PR DESCRIPTION
actually my archive implementation was not that good and when we added proper URL handling in #254, URL got broken, since parameters where part of the object

fix it with updating session.params
also added tests, so we can avoid that it will be broken :D

I did a test for #216, and it works fine. No difference to standard folder download
```python
path = ArtifactoryPath(
    "http://company.com:8080/artifactory/docker-devops/ace/coordinator-4.0.1-PullRequest0592.11",
    auth=("name", "password")
)
print(path.is_dir())
path.archive().writeto(out="my.zip", chunk_size=100 * 1024)
# exit()
with path.download_folder_archive(archive_type="zip", check_sum=True) as archive:
    with open(r"{0}".format("test.zip"), "wb") as out:
        out.write(archive.read())
```

![image](https://user-images.githubusercontent.com/51964909/130245677-7fa56399-1844-415e-ada9-8e66ef532c5f.png)
