### PR TITLE
RepositoryLocal improvement

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -707,6 +707,7 @@ class RepositoryLocal(Repository):
         packageType=Repository.GENERIC,
         dockerApiVersion=Repository.V1,
         repoLayoutRef="maven-2-default",
+        max_unique_tags=0,
     ):
         super(RepositoryLocal, self).__init__(artifactory)
         self.name = name
@@ -715,6 +716,7 @@ class RepositoryLocal(Repository):
         self.repoLayoutRef = repoLayoutRef
         self.archiveBrowsingEnabled = True
         self.dockerApiVersion = dockerApiVersion
+        self.max_unique_tags = max_unique_tags
 
     def _create_json(self):
         """
@@ -741,6 +743,12 @@ class RepositoryLocal(Repository):
             "archiveBrowsingEnabled": self.archiveBrowsingEnabled,
             "yumRootDepth": 0,
         }
+        """
+        Docker V2 API specific fields
+        """
+        if self.dockerApiVersion == Repository.V2:
+            data_json["maxUniqueTags"] = self.max_unique_tags
+
         return data_json
 
     def _read_response(self, response):


### PR DESCRIPTION
- Default docker API version set to V2 in order to reflect the current
  Artifacotry default
- maxUniqueTags exposed to the library user. Defaults to 0, as in
  Artifactory. Allows user to implment cleanup policy on new and
  existing registries/repositories.