### PR TITLE
Handling int arguments in create_aql_text method

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -2185,6 +2185,8 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
                 arg = "({})".format(json.dumps(arg))
             elif isinstance(arg, list):
                 arg = "({})".format(json.dumps(arg)).replace("[", "").replace("]", "")
+            elif isinstance(arg, int):
+                arg = "({})".format(arg)
             aql_query_text += arg
 
         return aql_query_text

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -1258,9 +1258,9 @@ class TestArtifactoryAql(unittest.TestCase):
         assert aql_text == 'items.find({"repo": "myrepo"})'
 
     def test_create_aql_text_list(self):
-        args = ["items.find()", ".include", ["name", "repo"]]
+        args = ["items.find()", ".include", ["name", "repo"], ".offset", 10, ".limit", 20]
         aql_text = self.aql.create_aql_text(*args)
-        assert aql_text == 'items.find().include("name", "repo")'
+        assert aql_text == 'items.find().include("name", "repo").offset(10).limit(20)'
 
     def test_create_aql_text_list_in_dict(self):
         args = [

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -1258,7 +1258,15 @@ class TestArtifactoryAql(unittest.TestCase):
         assert aql_text == 'items.find({"repo": "myrepo"})'
 
     def test_create_aql_text_list(self):
-        args = ["items.find()", ".include", ["name", "repo"], ".offset", 10, ".limit", 20]
+        args = [
+            "items.find()",
+            ".include",
+            ["name", "repo"],
+            ".offset",
+            10,
+            ".limit",
+            20,
+        ]
         aql_text = self.aql.create_aql_text(*args)
         assert aql_text == 'items.find().include("name", "repo").offset(10).limit(20)'
 


### PR DESCRIPTION
Hi,
I'm using this module in one of my projects and noticed that the `.offset` and `.limit` arguments are not properly handled in the `ArtifactoryPath.create_aql_text` static method. The values of these properties are usually of `int` type.

Check out this `syntax` section with an example of both properties
https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-Syntax

I've also updated one unit-test to cover these cases.