### PR TITLE
Fix jwt.exceptions.DecodeError

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -1267,7 +1267,10 @@ class Token(AdminObject):
         r.raise_for_status()
         response = r.json()
         access_token = response.get("access_token")
-        access_token_decoded = jwt.decode(access_token, verify=False)
+        access_token_decoded = jwt.decode(
+            access_token,
+            options={"verify_signature": False},
+        )
 
         self.token = response
         self.token_id = access_token_decoded.get("jti")

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     install_requires=[
         "requests",
         "python-dateutil",
-        "PyJWT",
+        "PyJWT~=2.0",
     ],
     zip_safe=False,
     package_data={"": ["README.md"]},


### PR DESCRIPTION
PyJWT v2.0.0 removed the `verify` parameter from the jwt.decode function.
This commit adapts the decode call to the new major version of PyJWT.
PyJWT is locked to only use v2.* to make sure compatability is kept
until v3.0.0 is released.

Reference: https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst#dropped-deprecated-verify-param-in-jwtdecode
Solves: #234