### PR TITLE
Bugfix: JSONDecodeError handling for simplejson

### DIFF
--- a/dohq_artifactory/exception.py
+++ b/dohq_artifactory/exception.py
@@ -1,5 +1,3 @@
-from json import JSONDecodeError
-
 import requests
 
 
@@ -25,7 +23,7 @@ def raise_for_status(response):
         try:
             response_json = exception.response.json()
             error_list = response_json.pop("errors", None)
-        except JSONDecodeError:
+        except requests.compat.JSONDecodeError:
             # not a JSON response
             raise ArtifactoryException(str(exception)) from exception
 

--- a/dohq_artifactory/exception.py
+++ b/dohq_artifactory/exception.py
@@ -5,7 +5,7 @@ class ArtifactoryException(Exception):
     pass
 
 
-def raise_for_status(response):
+def raise_for_status(response: requests.Response) -> None:
     """
     Custom raise_for_status method.
     Raises ArtifactoryException with clear message and keeps cause


### PR DESCRIPTION
This PR fixes JSONDecodeError exception handling when the `simplejson` package is available within the environment.

----

requests has a compat module that will use simplejson if it is available within the environment. We should catch the exception outlined in this module as it will reflect the json decoder used by requests.

Note that `requests.exceptions.JSONDecodeError` (and subsequently `requests.JSONDecodeError`) is not the same thing, and will not represent the same exception in this case due to the class initialization.