### PR TITLE
fix writeto progress_func: the last chunk

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1421,6 +1421,9 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
             file.write(chunk)
 
+        if real_chunk > 0:
+            progress_func(bytes_read + real_chunk, file_size)
+
 
 _artifactory_accessor = _ArtifactoryAccessor()
 


### PR DESCRIPTION
Hello.

The last read chunk can be less than chunk_size and the progress won't be reported in this case. My progress bar often stops near 99.7%/99.8%

```
for chunk in response.iter_content(chunk_size=chunk_size):
  real_chunk += len(chunk)
  if callable(progress_func) and real_chunk - chunk_size >= 0:
     ...
     real_chunk = 0
     ...
```

So, I added an additional call after the loop.

```
if real_chunk > 0:
    progress_func(bytes_read + real_chunk, file_size)
```