### PR TITLE
fix writeto progress_func: the last chunk

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1421,6 +1421,9 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
             file.write(chunk)
 
+        if real_chunk > 0:
+            progress_func(bytes_read + real_chunk, file_size)
+
 
 _artifactory_accessor = _ArtifactoryAccessor()
 


### PR DESCRIPTION
Hello. My progree bar often stops at 99.7% or 99.8% because  the last chunk can be smaller than chunk_size

```
        bytes_read = 0
        real_chunk = 0
        for chunk in response.iter_content(chunk_size=chunk_size):
            real_chunk += len(chunk)
            if callable(progress_func) and real_chunk - chunk_size >= 0:
                # Artifactory archives folders on fly and can reduce requested chunk size to 8kB, thus report
                # only when real chunk size met
                bytes_read += real_chunk
                real_chunk = 0
                progress_func(bytes_read, file_size)

            file.write(chunk)

        if real_chunk > 0:
            progress_func(bytes_read + real_chunk, file_size)
```