### PR TITLE
support python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
 
     steps:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -641,8 +641,8 @@ class _ScandirIter:
 
 
 _artifactory_access_parent_class = (
-        pathlib.WindowsPath if os.name == "nt" else pathlib.PosixPath
-    )
+    pathlib.WindowsPath if os.name == "nt" else pathlib.PosixPath
+)
 
 
 class _ArtifactoryAccessor(_artifactory_access_parent_class):

--- a/artifactory.py
+++ b/artifactory.py
@@ -640,12 +640,7 @@ class _ScandirIter:
         return self.iterator
 
 
-_artifactory_access_parent_class = (
-    pathlib.WindowsPath if os.name == "nt" else pathlib.PosixPath
-)
-
-
-class _ArtifactoryAccessor(_artifactory_access_parent_class):
+class _ArtifactoryAccessor:
 
     """
     Implements operations with Artifactory REST API

--- a/artifactory.py
+++ b/artifactory.py
@@ -640,11 +640,7 @@ class _ScandirIter:
         return self.iterator
 
 
-_artifactory_access_parent_class = None
-try:
-    _artifactory_access_parent_class = pathlib._Accessor
-except AttributeError:
-    _artifactory_access_parent_class = (
+_artifactory_access_parent_class = (
         pathlib.WindowsPath if os.name == "nt" else pathlib.PosixPath
     )
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -999,7 +999,7 @@ class _ArtifactoryAccessor:
         """
 
         if not pathobj.exists():
-            raise OSError(2, f"No such file or directory: {pathobj}")
+            raise FileNotFoundError(2, f"No such file or directory: {pathobj}")
 
         url = "/".join(
             [
@@ -1904,7 +1904,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         """
         try:
             self._accessor.unlink(self)
-        except ArtifactoryException:
+        except FileNotFoundError:
             if not missing_ok:
                 raise
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -640,7 +640,17 @@ class _ScandirIter:
         return self.iterator
 
 
-class _ArtifactoryAccessor(pathlib._Accessor):
+_artifactory_access_parent_class = None
+try:
+    _artifactory_access_parent_class = pathlib._Accessor
+except AttributeError:
+    _artifactory_access_parent_class = (
+        pathlib.WindowsPath if os.name == "nt" else pathlib.PosixPath
+    )
+
+
+class _ArtifactoryAccessor(_artifactory_access_parent_class):
+
     """
     Implements operations with Artifactory REST API
     """
@@ -1896,6 +1906,16 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         Changing access rights makes no sense for Artifactory.
         """
         raise NotImplementedError()
+
+    def unlink(self, missing_ok=False):
+        """
+        Removes a file or folder
+        """
+        try:
+            self._accessor.unlink(self)
+        except ArtifactoryException:
+            if not missing_ok:
+                raise
 
     def symlink_to(self, target, target_is_directory=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Filesystems",
     ],

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -801,7 +801,7 @@ class ArtifactoryAccessorTest(ClassSetup):
             status=404,
             body="Unable to find item",
         )
-        with self.assertRaises(OSError) as context:
+        with self.assertRaises(FileNotFoundError) as context:
             path.unlink()
 
         self.assertTrue("No such file or directory" in context.exception.strerror)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pre-commit
 
 [testenv]


### PR DESCRIPTION
Python 3.11 is expected to be released in October 2022.

`pathlib._Accessor` was removed from Python 3.11: https://github.com/python/cpython/pull/25701 .
There is a related issue : https://github.com/devopshq/artifactory/issues/372 , this PR will fix it.


Related links:
- [Python 3.11 Release Schedule](https://peps.python.org/pep-0664/)
- [setup-python action - Advanced Usage](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md)