### PR TITLE
fix: add callable check to progress_bar

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1422,7 +1422,7 @@ class _ArtifactoryAccessor:
 
             file.write(chunk)
 
-        if real_chunk > 0:
+        if callable(progress_func) and real_chunk > 0:
             progress_func(bytes_read + real_chunk, file_size)
 
 


### PR DESCRIPTION
If `progress_func` is `None` a `TypeError` (`TypeError: 'NoneType' object is not callable`) is raised. Add check to verify that `progress_func` is callable.

Fixes #378.