### PR TITLE
check if missing API caused by lack of Pro license

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -138,7 +138,7 @@ class AdminObject(object):
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}/{getattr(self, self.resource_name)}"
         r = self._session.get(request_url, auth=self._auth)
         if 404 == r.status_code or 400 == r.status_code:
-            if 'Artifactory Pro' in r.text:
+            if "Artifactory Pro" in r.text:
                 logger.debug(
                     f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
                     f"Pro license (see jfrog.com/artifactory/features)"
@@ -1357,7 +1357,7 @@ class Token(AdminObject):
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}"
         r = self._session.get(request_url, auth=self._auth)
         if 404 == r.status_code or 400 == r.status_code:
-            if 'Artifactory Pro' in r.text:
+            if "Artifactory Pro" in r.text:
                 logger.debug(
                     f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
                     f"Pro license (see jfrog.com/artifactory/features)"

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -141,7 +141,7 @@ class AdminObject(object):
             if "Artifactory Pro" in r.text:
                 logger.debug(
                     f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
-                    f"Pro license (see jfrog.com/artifactory/features)"
+                    f"Pro license (see https://jfrog.com/artifactory/features)"
                 )
             else:
                 logger.debug(
@@ -1360,7 +1360,7 @@ class Token(AdminObject):
             if "Artifactory Pro" in r.text:
                 logger.debug(
                     f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
-                    f"Pro license (see jfrog.com/artifactory/features)"
+                    f"Pro license (see https://jfrog.com/artifactory/features)"
                 )
             else:
                 logger.debug(

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -137,16 +137,15 @@ class AdminObject(object):
         )
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}/{getattr(self, self.resource_name)}"
         r = self._session.get(request_url, auth=self._auth)
-        if 404 == r.status_code or 400 == r.status_code:
-            if "Artifactory Pro" in r.text:
-                logger.debug(
-                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
-                    f"Pro license (see https://jfrog.com/artifactory/features)"
-                )
-            else:
-                logger.debug(
-                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
-                )
+        if 404 == r.status_code:
+            logger.debug(
+                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
+            )
+            return False
+        elif 400 == r.status_code:
+            logger.debug(
+                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] error: {r.json()}"
+            )
             return False
         else:
             logger.debug(
@@ -1356,16 +1355,15 @@ class Token(AdminObject):
         )
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}"
         r = self._session.get(request_url, auth=self._auth)
-        if 404 == r.status_code or 400 == r.status_code:
-            if "Artifactory Pro" in r.text:
-                logger.debug(
-                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
-                    f"Pro license (see https://jfrog.com/artifactory/features)"
-                )
-            else:
-                logger.debug(
-                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
-                )
+        if 404 == r.status_code:
+            logger.debug(
+                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
+            )
+            return False
+        elif 400 == r.status_code:
+            logger.debug(
+                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] error: {r.json()}"
+            )
             return False
         else:
             logger.debug(

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -138,9 +138,15 @@ class AdminObject(object):
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}/{getattr(self, self.resource_name)}"
         r = self._session.get(request_url, auth=self._auth)
         if 404 == r.status_code or 400 == r.status_code:
-            logger.debug(
-                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
-            )
+            if 'Artifactory Pro' in r.text:
+                logger.debug(
+                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
+                    f"Pro license (see jfrog.com/artifactory/features)"
+                )
+            else:
+                logger.debug(
+                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
+                )
             return False
         else:
             logger.debug(
@@ -1351,9 +1357,15 @@ class Token(AdminObject):
         request_url = f"{self.base_url}/{self.prefix_uri}/{self._uri}"
         r = self._session.get(request_url, auth=self._auth)
         if 404 == r.status_code or 400 == r.status_code:
-            logger.debug(
-                f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
-            )
+            if 'Artifactory Pro' in r.text:
+                logger.debug(
+                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] not available without Artifactory"
+                    f"Pro license (see jfrog.com/artifactory/features)"
+                )
+            else:
+                logger.debug(
+                    f"{self.__class__.__name__} [{getattr(self, self.resource_name)}] does not exist"
+                )
             return False
         else:
             logger.debug(


### PR DESCRIPTION
When using Artifactory OSS some API calls are blocked behind a 400 response with a specific message.

Add better logging for this case.

Fixes #356 