### PR TITLE
URL quoting for matrix parameters

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1142,7 +1142,7 @@ class _ArtifactoryAccessor:
         explode_archive_atomic=None,
         checksum=None,
         by_checksum=False,
-        **kwargs,  # TODO: v.10.0: replace with explicit kwarg quote_parameters; for now kwargs for forward compat
+        quote_parameters=None,  # TODO: v0.10.0: change default to True
     ):
         """
         Uploads a given file-like object
@@ -1164,7 +1164,6 @@ class _ArtifactoryAccessor:
             default False until v0.10.0
         """
 
-        quote_parameters = kwargs.get("quote_parameters")
         if quote_parameters is None:
             warn(
                 "The current default value of quote_parameters (False) will change to True in v0.10.0.\n"

--- a/artifactory.py
+++ b/artifactory.py
@@ -315,21 +315,31 @@ class HTTPResponseWrapper(object):
         return int(self.getheader("content-length"))
 
 
-def encode_matrix_parameters(parameters):
+def encode_matrix_parameters(parameters, quote_parameters):
     """
     Performs encoding of url matrix parameters from dictionary to
     a string.
     See http://www.w3.org/DesignIssues/MatrixURIs.html for specs.
+    If quote_parameters is true, then apply URL quoting to the values and the parameter names.
     """
     result = []
 
     for param in iter(sorted(parameters)):
-        if isinstance(parameters[param], (list, tuple)):
-            value = f";{param}=".join(parameters[param])
-        else:
-            value = parameters[param]
+        raw_value = parameters[param]
 
-        result.append("=".join((param, value)))
+        resolved_param = urllib.parse.quote(param) if quote_parameters else param
+
+        if isinstance(raw_value, (list, tuple)):
+            values = (
+                [urllib.parse.quote(v) for v in raw_value]
+                if quote_parameters
+                else raw_value
+            )
+            value = f";{resolved_param}=".join(values)
+        else:
+            value = urllib.parse.quote(raw_value) if quote_parameters else raw_value
+
+        result.append("=".join((resolved_param, value)))
 
     return ";".join(result)
 

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -910,9 +910,7 @@ class ArtifactoryPathTest(ClassSetup):
             file.write("I am a test file")
 
             constructed_url = f"{path}{test_file.name};{matrix_parameters}"
-            responses.add(
-                responses.PUT, constructed_url, status=200, match_querystring=True
-            )
+            responses.add(responses.PUT, constructed_url, status=200)
 
             path.deploy_file(
                 test_file,
@@ -1092,9 +1090,7 @@ class ArtifactoryPathTest(ClassSetup):
             file.write("I am a test file")
 
             constructed_url = f"{path}{test_file.name};{matrix_parameters}"
-            responses.add(
-                responses.PUT, constructed_url, status=200, match_querystring=True
-            )
+            responses.add(responses.PUT, constructed_url, status=200)
 
             path.deploy_deb(
                 test_file,

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -1005,7 +1005,10 @@ class ArtifactoryPathTest(ClassSetup):
                 json=self.file_stat_without_modification_date,
                 status=200,
             )
-            self.path.deploy_by_checksum(sha1=self.sha1)
+            self.path.deploy_by_checksum(sha1=self.sha1, quote_parameters=True)
+            # TODO: v0.10.0 - remove quote_parameters explicit setting
+            # These tests should allow the default value of the underlying method to be used.
+            # In this version, we set it explicitly to avoid the warning.
 
             self.assertEqual(len(rsps.calls), 1)
             self.assertEqual(rsps.calls[0].request.url, self.artifact_url)
@@ -1027,7 +1030,10 @@ class ArtifactoryPathTest(ClassSetup):
                 json=self.file_stat_without_modification_date,
                 status=200,
             )
-            self.path.deploy_by_checksum(sha256=self.sha256)
+            self.path.deploy_by_checksum(sha256=self.sha256, quote_parameters=True)
+            # TODO: v0.10.0 - remove quote_parameters explicit setting
+            # These tests should allow the default value of the underlying method to be used.
+            # In this version, we set it explicitly to avoid the warning.
 
             self.assertEqual(len(rsps.calls), 1)
             self.assertEqual(rsps.calls[0].request.url, self.artifact_url)
@@ -1049,7 +1055,10 @@ class ArtifactoryPathTest(ClassSetup):
                 json=self.file_stat_without_modification_date,
                 status=200,
             )
-            self.path.deploy_by_checksum(checksum=self.sha1)
+            self.path.deploy_by_checksum(checksum=self.sha1, quote_parameters=True)
+            # TODO: v0.10.0 - remove quote_parameters explicit setting
+            # These tests should allow the default value of the underlying method to be used.
+            # In this version, we set it explicitly to avoid the warning.
 
             self.assertEqual(len(rsps.calls), 1)
             self.assertEqual(rsps.calls[0].request.url, self.artifact_url)
@@ -1066,7 +1075,10 @@ class ArtifactoryPathTest(ClassSetup):
                 json=self.file_stat_without_modification_date,
                 status=200,
             )
-            self.path.deploy_by_checksum(checksum=self.sha256)
+            self.path.deploy_by_checksum(checksum=self.sha256, quote_parameters=True)
+            # TODO: v0.10.0 - remove quote_parameters explicit setting
+            # These tests should allow the default value of the underlying method to be used.
+            # In this version, we set it explicitly to avoid the warning.
 
             self.assertEqual(len(rsps.calls), 1)
             self.assertEqual(rsps.calls[0].request.url, self.artifact_url)
@@ -1089,7 +1101,12 @@ class ArtifactoryPathTest(ClassSetup):
                 status=400,
             )
             with self.assertRaises(ArtifactoryException) as context:
-                self.path.deploy_by_checksum(sha1=f"{self.sha1}invalid")
+                self.path.deploy_by_checksum(
+                    sha1=f"{self.sha1}invalid", quote_parameters=True
+                )
+                # TODO: v0.10.0 - remove quote_parameters explicit setting
+                # These tests should allow the default value of the underlying method to be used.
+                # In this version, we set it explicitly to avoid the warning.
 
             self.assertEqual(str(context.exception), "Checksum values not provided")
 
@@ -1143,7 +1160,11 @@ class ArtifactoryPathTest(ClassSetup):
                 component="contrib",
                 architecture="amd64",
                 parameters={"z.additional": "param"},
+                quote_parameters=True,
             )
+            # TODO: v0.10.0 - remove quote_parameters explicit setting
+            # These tests should allow the default value of the underlying method to be used.
+            # In this version, we set it explicitly to avoid the warning.
 
         request_url = responses.calls[1].request.url
         self.assertEqual(request_url, constructed_url)

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -3,8 +3,10 @@ import os
 import pathlib
 import tempfile
 import unittest
+from urllib.parse import quote as quote_original
 
 import dateutil
+import mock
 import responses
 from responses.matchers import json_params_matcher
 from responses.matchers import query_param_matcher
@@ -20,17 +22,40 @@ from dohq_artifactory.admin import User
 
 class UtilTest(unittest.TestCase):
     def test_matrix_encode(self):
-        params = {"foo": "bar", "qux": "asdf"}
+        with mock.patch("urllib.parse.quote", new=mock.Mock(wraps=quote_original)) as q:
 
-        s = artifactory.encode_matrix_parameters(params)
+            params = {"foo": "bar", "qux": "asdf"}
 
-        self.assertEqual(s, "foo=bar;qux=asdf")
+            s = artifactory.encode_matrix_parameters(params, quote_parameters=False)
 
-        params = {"baz": ["bar", "quux"], "foo": "asdf"}
+            self.assertEqual(s, "foo=bar;qux=asdf")
+            q.assert_not_called()
 
-        s = artifactory.encode_matrix_parameters(params)
+            params = {"baz": ["bar", "quux"], "foo": "asdf"}
 
-        self.assertEqual(s, "baz=bar;baz=quux;foo=asdf")
+            s = artifactory.encode_matrix_parameters(params, quote_parameters=False)
+
+            self.assertEqual(s, "baz=bar;baz=quux;foo=asdf")
+            q.assert_not_called()
+
+            # Test with quoting
+            params = {"b?az": ["b%ar", "quux"], "foo?%0": "a/s&d%f?"}
+
+            s = artifactory.encode_matrix_parameters(params, quote_parameters=True)
+
+            expected_calls = []
+            for k, v in params.items():
+                expected_calls.append(mock.call(k))
+                if isinstance(v, (list, tuple)):
+                    for vi in v:
+                        expected_calls.append(mock.call(vi))
+                else:
+                    expected_calls.append(mock.call(v))
+
+            q.assert_has_calls(expected_calls)
+            assert q.call_count == len(expected_calls)
+
+            self.assertEqual(s, "b%3Faz=b%25ar;b%3Faz=quux;foo%3F%250=a/s%26d%25f%3F")
 
     def test_escape_chars(self):
         s = artifactory.escape_chars("a,b|c=d")

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -5,7 +5,6 @@ import tempfile
 import unittest
 
 import dateutil
-import mock
 import responses
 from responses.matchers import json_params_matcher
 from responses.matchers import query_param_matcher

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -941,7 +941,7 @@ class ArtifactoryPathTest(ClassSetup):
             for quote_params in (None, True, False):
                 with mock.patch(
                     "urllib.parse.quote", new=mock.Mock(wraps=quote_original)
-                ) as q, mock.patch("artifactory.warn") as w:
+                ) as q:
                     path.deploy_file(
                         test_file,
                         explode_archive=True,
@@ -955,13 +955,12 @@ class ArtifactoryPathTest(ClassSetup):
                     )
                     # TODO: v0.10.0 - None test will not be needed, warn test will not be needed
                     if quote_params is None:
-                        w.assert_called_once_with(
-                            "The current default value of quote_parameters (False) will change to True in v0.10.0.\n"
-                            "To ensure consistent behavior and remove this warning, explicitly set a value for quote_parameters.\n"
-                            "For more details see https://github.com/devopshq/artifactory/issues/408."
+                        self.assertWarnsRegex(
+                            UserWarning,
+                            r"^The current default value of quote_parameters \(False\) will change to True in v0\.10\.0\.\n"
+                            r"To ensure consistent behavior and remove this warning, explicitly set a value for quote_parameters.\n"
+                            r"For more details see https://github\.com/devopshq/artifactory/issues/408\.$",
                         )
-                    else:
-                        w.assert_not_called()
 
                     if quote_params:
                         assert q.call_count == 7  # once for each key and value


### PR DESCRIPTION
Fixes #408 

Provides for quoting of matrix parameters to ensure their values (and names) end up in Artifactory correctly, but optionally.

- actual implementation is in `encode_matrix_parameters` with a new required parameter `quote_parameters` (I consider this method not really part of the public API)
- public-facing `deploy` method will take a parameter of the same name, to pass into the encode function
- for now, the parameter has a default of `None` instead of `False`
  - this is so that we can detect when no value was passed, and warn about the planned change of default in `v0.10.0`
  - that change will require some minor implementation changes to be made, and I've added `TODO`s to help find those leading up to the change
- unit tests added or changed for the new functionality
  - test `True`, `False`, and `None` (ensure warnings; `None` tests should be removed when the default changes)
  - some unit tests changed in order to avoid littering the test output with warnings (with TODOs to remove later)

Still left to do:
- integration tests: I don't have a pro license key to use locally, so unfortunately I'll probably rely on CI for the integration runs