### PR TITLE
Add `$DOHQ_ARTIFACTORY_PYTHON_CFG` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1409,10 +1409,10 @@ path = ArtifactoryPath(
 
 ## Global Configuration File ##
 
-Artifactory Python module also can specify all connection-related settings in a central file, 
-```~/.artifactory_python.cfg``` that is read upon the creation of first ```ArtifactoryPath``` object and is stored 
-globally. For instance, you can specify per-instance settings of authentication tokens, so that you won't need to 
-explicitly pass ```auth``` parameter to ```ArtifactoryPath```.
+Artifactory Python module also can specify all connection-related settings in a central file, given by environment
+variable ```$DOHQ_ARTIFACTORY_PYTHON_CFG``` (default if not set: ```~/.artifactory_python.cfg```) that is read upon
+the creation of first ```ArtifactoryPath``` object and is stored globally. For instance, you can specify per-instance
+settings of authentication tokens, so that you won't need to explicitly pass ```auth``` parameter to ```ArtifactoryPath```.
 
 Example:
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -63,9 +63,12 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-default_config_path = "~/.artifactory_python.cfg"
-if platform.system() == "Windows":
+if "DOHQ_ARTIFACTORY_PYTHON_CFG" in os.environ:
+    default_config_path = os.environ["DOHQ_ARTIFACTORY_PYTHON_CFG"]
+elif platform.system() == "Windows":
     default_config_path = "~\\.artifactory_python.cfg"
+else:
+    default_config_path = "~/.artifactory_python.cfg"
 global_config = None
 
 


### PR DESCRIPTION
`$DOHQ_ARTIFACTORY_PYTHON_CFG ` environment variable for overriding the default location of configuration file without a need to make changes in the code. It helps in multi-user workflow, when writing to `$HOME` is restricted or when the file needs to be stored in designated location.

As added bonus, it enables a semi-compilance with XDG Base Directory Specification for interested parties.