### PR TITLE
Handle requests.exceptions.JSONDecodeError

### DIFF
--- a/dohq_artifactory/exception.py
+++ b/dohq_artifactory/exception.py
@@ -23,7 +23,7 @@ def raise_for_status(response: requests.Response) -> None:
         try:
             response_json = exception.response.json()
             error_list = response_json.pop("errors", None)
-        except requests.compat.JSONDecodeError:
+        except (requests.compat.JSONDecodeError, requests.exceptions.JSONDecodeError):
             # not a JSON response
             raise ArtifactoryException(str(exception)) from exception
 


### PR DESCRIPTION
In requests v2.27.0, `requests.exceptions.JSONDecodeError` was added to decrease inconsistencies in the library.

This PR adds handling of this exception to maintain compatibility with versions prior to, and after this change.

Fixes #414.