### PR TITLE
Python 3.11

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1659,6 +1659,12 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         """
         self._accessor.rmdir(self)
 
+    def _scandir(self):
+        """
+        Override Path._scandir. Only required on Python >= 3.11
+        """
+        return self._accessor.scandir(self)
+
     def download_stats(self, pathobj=None):
         """
          Item statistics record the number of times an item was downloaded, last download date and last downloader.

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -455,6 +455,12 @@ class ClassSetup(unittest.TestCase):
             ],
             "uri": "http://artifactory.local/artifactory/api/storage/libs-release-local",
         }
+        self.dir_mkdir = {
+            "repo": "libs-release-local",
+            "path": "/testdir",
+            "created": "2014-02-18T15:35:29.361+04:00",
+            "uri": "http://artifactory.local/artifactory/api/storage/libs-release-local",
+        }
 
         self.property_data = """{
           "properties" : {
@@ -675,8 +681,39 @@ class ArtifactoryAccessorTest(ClassSetup):
 
         self.assertRaises(OSError, a.listdir, path)
 
+    @responses.activate
     def test_mkdir(self):
-        pass
+        a = self.cls()
+
+        # Directory
+        path = ArtifactoryPath(
+            "http://artifactory.local/artifactory/libs-release-local/testdir"
+        )
+
+        constructed_url_stat = "http://artifactory.local/artifactory/api/storage/libs-release-local/testdir"
+        constructed_url_mkdir = (
+            "http://artifactory.local/artifactory/libs-release-local/testdir/"
+        )
+        responses.add(
+            responses.GET,
+            constructed_url_stat,
+            status=404,
+            json="""
+{
+  "errors" : [ {
+    "status" : 404,
+    "message" : "Not Found."
+  } ]
+}
+""",
+        )
+        responses.add(
+            responses.PUT,
+            constructed_url_mkdir,
+            status=200,
+            json=self.dir_mkdir,
+        )
+        a.mkdir(path, "")
 
     @responses.activate
     def test_get_properties(self):


### PR DESCRIPTION
I see no way of reusing the current versions of mkdir and rmdir from pathlib. So we just need to copy them and implement on our own. The versions here are copied verbatim from Python 3.10.

Edit: Extended the patch to also fix glob. Slightly different problem. We don't need to override glob itself,
but the newly added _scandir which we need to redirect to our accessor.

I implemented a basic UT for mkdir to understand how the UTs work. Note that this UT does *not* actually test the
bug since it tests directly the ArtifactoryAccessor and not the ArtifactoryPath.

Fixes: #415
Fixes: #396 