### PR TITLE
ArtifactoryPath: fix iterdir with Python 3.11

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1811,6 +1811,8 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
                 continue
             yield self._make_child_relpath(name)
 
+    iterdir = __iter__
+
     def read_text(self, encoding=None, errors=None):
         """
         Read file content


### PR DESCRIPTION
On Python 3.11, pathlib's `iterdir()` calls directly to `os.listdir()`, so it does not go through `ArtifactoryAccessor`.

Similar to commit 5278d0686671c8dea0401a21c2d40b04d3e0ffb5, override `iterdir()` so that we call our own `ArtifactoryPath` implementation.