### PR TITLE
Update README.md for aql example

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ aqlargs = [
         ]
     },
     ".include",
-    ["repo", "path", "name"],
+    ["repo", "path", "name", "type"],
     ".sort",
     {"$asc": ["repo", "path", "name"]},
 ]


### PR DESCRIPTION
added "type" key for aql example for aql results to work correctly with `from_aql` method for ArtifactoryPath

if "type" isnt included in aql response dict(s) it will raise ArtifactoryException and thus example isnt working

```
    def from_aql(self, result):
        """
        Convert raw AQL result to pathlib object
        :param result: ONE raw result
        :return:
        """
        result_type = result.get("type")
        if result_type not in ("file", "folder"):
            raise ArtifactoryException(
                f"Path object with type '{result_type}' doesn't support. File or folder only"
            )
```

