### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -20,18 +20,18 @@ Development takes place on GitHub, where the git-flow branch structure is used:
 
 ### Prepare development environment
 It is recommended to use Unix systems. You can use free Oracle Virtualbox and Ubuntu.  
-Setup script for Ubuntu system (python version must be 3.7+):
+Setup script for Ubuntu system (python version must be 3.8+):
 ```bash
-python3.7 -m pip install tox
-python3.7 -m pip install .[tests]
-python3.7 -m pytest -munit
+python3 -m pip install tox
+python3 -m pip install .[tests]
+python3 -m pytest -munit
 
 # install ruby (required for pre-commit)
 sudo apt install ruby
 
 # run pre-commit
-python3.7 -m pre_commit install
-python3.7 -m pre_commit run --all-files
+python3 -m pre_commit install
+python3 -m pre_commit run --all-files
 ```
 
 If you use another system procedure might be different.  

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
https://devguide.python.org/versions/


Branch | Schedule | Status | First release | End of life | Release manager
-- | -- | -- | -- | -- | --
3.7 | PEP 537 | end-of-life | 2018-06-27 | 2023-06-27 | Ned Deily
