### PR TITLE
Add support to get docker image tag list

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -2321,6 +2321,33 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         )
         return obj
 
+    def get_docker_images(self, docker_repo):
+        """
+        Get Docker image list from docker repo
+        :param docker_repo: Docker repository to list
+        :return: List[image]
+        """
+        url = f"{self.drive.rstrip('/')}/api/docker/{docker_repo}/v2/_catalog"
+        r = self.session.get(url)
+        raise_for_status(r)
+        content = r.json()
+
+        return content["repositories"]
+
+    def get_docker_image_tags(self, docker_repo, docker_image):
+        """
+        Get Docker image list from docker repo
+        :param docker_repo: Docker repository
+        :param docker_image: Docker image to list
+        :return: List[tag]
+        """
+        url = f"{self.drive.rstrip('/')}/api/docker/{docker_repo}/v2/{docker_image}/tags/list"
+        r = self.session.get(url)
+        raise_for_status(r)
+        content = r.json()
+
+        return content["tags"]
+
     def promote_docker_image(
         self,
         source_repo,


### PR DESCRIPTION
Get docker image list

```Python
from artifactory import ArtifactoryPath

url = 'https://artifactory.example.com/artifactory'
apikey = 'xxx'

p = ArtifactoryPath(url, apikey=apikey)

docker_repo = 'foo'

for docker_image in p.get_docker_images(docker_repo):
    for docker_image_tag in p.get_docker_image_tags(docker_repo, docker_image):
        src = f'{docker_image}:{docker_image_tag}'
```

Reference:
* https://jfrog.com/help/r/jfrog-rest-apis/list-docker-repositories
* https://jfrog.com/help/r/jfrog-rest-apis/list-docker-tags