### PR TITLE
GenericRepository: fix unpickling of objects

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -660,6 +660,12 @@ class GenericRepository(AdminObject):
         __div__ = __truediv__
         __rdiv__ = __rtruediv__
 
+    def __setstate__(self, state):
+        self.__dict__ = state
+
+    def __getstate__(self):
+        return self.__dict__
+
 
 class Repository(GenericRepository):
     # List package_type from wiki:


### PR DESCRIPTION
This allows them to be passed across process boundaries when using `concurrent.futures.ProcessPoolExecutor`.  Without this, a `RecursionError` occurs.

The issue stems from `GenericRepository.__getattr__` calling `getattr(self.path, ...)`.  `GenericRepository.path` is a property, so it is found, but it then calls `self._artifactory.joinpath(...)` and `self._artifactory` is not yet present on the partially-restored `GenericRepository`, resulting in a call to
`GenericRepository.__getattr__`, etc.

This fix ensures that `self._artifactory` will be restored to the object early enough in unpickling to avoid the issue.