### PR TITLE
ArtifactoryPath: override PurePath.__reduce__ to fix pickling

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1565,6 +1565,12 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         super(ArtifactoryPath, self)._init(*args, **kwargs)
 
+    def __reduce__(self):
+        # pathlib.PurePath.__reduce__ doesn't include instance state, but we
+        # have state that needs to be included when pickling
+        pathlib_reduce = super().__reduce__()
+        return pathlib_reduce[0], pathlib_reduce[1], self.__dict__
+
     @property
     def top(self):
         obj = ArtifactoryPath(self.drive)


### PR DESCRIPTION
`pathlib.PurePath` instances can be reconstructed from only `self._parts`, so that is all that `PurePath.__reduce__` returns.  This means that pickling an `ArtifactoryPath` objects strips out all other instance state including, crucially, `self.session` and the auth data it includes.

This commit overrides `__reduce__` to include `self.__dict__` in the returned tuple, which is restored as instance state on unpickle per https://docs.python.org/3/library/pickle.html#object.__reduce__.