### PR TITLE
fix: add default_deployment_repo_name to constructor

### DIFF
--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -865,6 +865,7 @@ class RepositoryVirtual(GenericRepository):
         package_type=Repository.GENERIC,
         *,
         packageType=None,
+        default_deployment_repo_name=None
     ):
         super(RepositoryVirtual, self).__init__(artifactory)
         self.name = name


### PR DESCRIPTION
Fix an error that was introduced with https://github.com/devopshq/artifactory/pull/461.

The previous change can not work if the variable is not also added to the constructor.
