### PR TITLE
Python 3.12 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/humitos/mirrors-autoflake
-    rev: v1.1
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: ['-i', '--remove-all-unused-imports']
@@ -19,7 +19,7 @@ repos:
       hooks:
       -   id: reorder-python-imports
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/mgedmin/check-python-versions

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Filesystems",
     ],

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -102,7 +102,7 @@ class ArtifactoryFlavorTest(unittest.TestCase):
         )
         check(
             "https://example.com/artifactory/foo/example.com/bar",
-            "https://example.com/artifactory/foo/example.com/bar"
+            "https://example.com/artifactory/foo/example.com/bar",
         )
         check(
             "https://example.com/artifactory/foo/#1",
@@ -140,28 +140,28 @@ class ArtifactoryFlavorTest(unittest.TestCase):
 
         check(".com", ("", "", ".com"))
         check("example1.com", ("", "", "example1.com"))
-        check("example2.com/artifactory", ("example2.com/artifactory", "", ""))
-        check("example2.com/artifactory/", ("example2.com/artifactory", "", ""))
-        check("example3.com/artifactory/foo", ("example3.com/artifactory", "/foo/", ""))
+        check("example2.com/artifactory", ("example2.com/artifactory", "/", ""))
+        check("example2.com/artifactory/", ("example2.com/artifactory", "/", ""))
+        check("example3.com/artifactory/foo", ("example3.com/artifactory", "/", "foo"))
         check(
             "example3.com/artifactory/foo/bar",
-            ("example3.com/artifactory", "/foo/", "bar"),
+            ("example3.com/artifactory", "/", "foo/bar"),
         )
         check(
             "artifactory.local/artifactory/foo/bar",
-            ("artifactory.local/artifactory", "/foo/", "bar"),
+            ("artifactory.local/artifactory", "/", "foo/bar"),
         )
         check(
             "http://artifactory.local/artifactory/foo/bar",
-            ("http://artifactory.local/artifactory", "/foo/", "bar"),
+            ("http://artifactory.local/artifactory", "/", "foo/bar"),
         )
         check(
             "https://artifactory.a.b.c.d/artifactory/foo/bar",
-            ("https://artifactory.a.b.c.d/artifactory", "/foo/", "bar"),
+            ("https://artifactory.a.b.c.d/artifactory", "/", "foo/bar"),
         )
         check(
             "https://artifactory.a.b.c.d/artifactory/foo/artifactory/bar",
-            ("https://artifactory.a.b.c.d/artifactory", "/foo/", "artifactory/bar"),
+            ("https://artifactory.a.b.c.d/artifactory", "/", "foo/artifactory/bar"),
         )
 
     def test_special_characters(self):
@@ -169,32 +169,32 @@ class ArtifactoryFlavorTest(unittest.TestCase):
         https://github.com/devopshq/artifactory/issues/90
         """
         check = self._check_splitroot
-        check("https://a/b/`", ("https://a", "/b/", "`"))
-        check("https://a/b/~", ("https://a", "/b/", "~"))
-        check("https://a/b/!", ("https://a", "/b/", "!"))
-        check("https://a/b/@", ("https://a", "/b/", "@"))
-        check("https://a/b/#", ("https://a", "/b/", "#"))
-        check("https://a/b/$", ("https://a", "/b/", "$"))
-        check("https://a/b/%", ("https://a", "/b/", "%"))
-        check("https://a/b/^", ("https://a", "/b/", "^"))
-        check("https://a/b/&", ("https://a", "/b/", "&"))
-        check("https://a/b/*", ("https://a", "/b/", "*"))
-        check("https://a/b/(", ("https://a", "/b/", "("))
-        check("https://a/b/)", ("https://a", "/b/", ")"))
-        check("https://a/b/[", ("https://a", "/b/", "["))
-        check("https://a/b/]", ("https://a", "/b/", "]"))
-        check("https://a/b/{", ("https://a", "/b/", "{"))
-        check("https://a/b/}", ("https://a", "/b/", "}"))
-        check("https://a/b/|", ("https://a", "/b/", "|"))
-        check("https://a/b/\\", ("https://a", "/b/", "\\"))
-        check("https://a/b/:", ("https://a", "/b/", ":"))
-        check("https://a/b/;", ("https://a", "/b/", ";"))
-        check("https://a/b/'", ("https://a", "/b/", "'"))
-        check('https://a/b/"', ("https://a", "/b/", '"'))
-        check("https://a/b/,", ("https://a", "/b/", ","))
-        check("https://a/b/<", ("https://a", "/b/", "<"))
-        check("https://a/b/>", ("https://a", "/b/", ">"))
-        check("https://a/b/?", ("https://a", "/b/", "?"))
+        check("https://a/b/`", ("https://a", "/", "b/`"))
+        check("https://a/b/~", ("https://a", "/", "b/~"))
+        check("https://a/b/!", ("https://a", "/", "b/!"))
+        check("https://a/b/@", ("https://a", "/", "b/@"))
+        check("https://a/b/#", ("https://a", "/", "b/#"))
+        check("https://a/b/$", ("https://a", "/", "b/$"))
+        check("https://a/b/%", ("https://a", "/", "b/%"))
+        check("https://a/b/^", ("https://a", "/", "b/^"))
+        check("https://a/b/&", ("https://a", "/", "b/&"))
+        check("https://a/b/*", ("https://a", "/", "b/*"))
+        check("https://a/b/(", ("https://a", "/", "b/("))
+        check("https://a/b/)", ("https://a", "/", "b/)"))
+        check("https://a/b/[", ("https://a", "/", "b/["))
+        check("https://a/b/]", ("https://a", "/", "b/]"))
+        check("https://a/b/{", ("https://a", "/", "b/{"))
+        check("https://a/b/}", ("https://a", "/", "b/}"))
+        check("https://a/b/|", ("https://a", "/", "b/|"))
+        check("https://a/b/\\", ("https://a", "/", "b/\\"))
+        check("https://a/b/:", ("https://a", "/", "b/:"))
+        check("https://a/b/;", ("https://a", "/", "b/;"))
+        check("https://a/b/'", ("https://a", "/", "b/'"))
+        check('https://a/b/"', ("https://a", "/", 'b/"'))
+        check("https://a/b/,", ("https://a", "/", "b/,"))
+        check("https://a/b/<", ("https://a", "/", "b/<"))
+        check("https://a/b/>", ("https://a", "/", "b/>"))
+        check("https://a/b/?", ("https://a", "/", "b/?"))
 
     def test_splitroot_custom_drv(self):
         """https://github.com/devopshq/artifactory/issues/31 and
@@ -204,75 +204,75 @@ class ArtifactoryFlavorTest(unittest.TestCase):
 
         check(
             "https://artifactory.example.com",
-            ("https://artifactory.example.com", "", ""),
+            ("https://artifactory.example.com", "/", ""),
         )
         check(
             "https://artifactory.example.com/",
-            ("https://artifactory.example.com", "", ""),
+            ("https://artifactory.example.com", "/", ""),
         )
         check(
             "https://artifactory.example.com/root",
-            ("https://artifactory.example.com", "/root/", ""),
+            ("https://artifactory.example.com", "/", "root"),
         )
         check(
             "https://artifactory.example.com/root/",
-            ("https://artifactory.example.com", "/root/", ""),
+            ("https://artifactory.example.com", "/", "root"),
         )
         check(
             "https://artifactory.example.com/root/parts",
-            ("https://artifactory.example.com", "/root/", "parts"),
+            ("https://artifactory.example.com", "/", "root/parts"),
         )
         check(
             "https://artifactory.example.com/root/parts/",
-            ("https://artifactory.example.com", "/root/", "parts"),
+            ("https://artifactory.example.com", "/", "root/parts"),
         )
         check(
-            "https://artifacts.example.com", ("https://artifacts.example.com", "", "")
+            "https://artifacts.example.com", ("https://artifacts.example.com", "/", "")
         )
         check(
-            "https://artifacts.example.com/", ("https://artifacts.example.com", "", "")
+            "https://artifacts.example.com/", ("https://artifacts.example.com", "/", "")
         )
         check(
             "https://artifacts.example.com/root",
-            ("https://artifacts.example.com", "/root/", ""),
+            ("https://artifacts.example.com", "/", "root"),
         )
         check(
             "https://artifacts.example.com/root/",
-            ("https://artifacts.example.com", "/root/", ""),
+            ("https://artifacts.example.com", "/", "root"),
         )
         check(
             "https://artifacts.example.com/root/parts",
-            ("https://artifacts.example.com", "/root/", "parts"),
+            ("https://artifacts.example.com", "/", "root/parts"),
         )
         check(
             "https://artifacts.example.com/root/parts/",
-            ("https://artifacts.example.com", "/root/", "parts"),
+            ("https://artifacts.example.com", "/", "root/parts"),
         )
         check(
             "https://artifacts.example.com/root/artifactory/parts/",
-            ("https://artifacts.example.com", "/root/", "artifactory/parts"),
+            ("https://artifacts.example.com", "/", "root/artifactory/parts"),
         )
         check(
             "https://artifacts.example.com/artifacts",
-            ("https://artifacts.example.com", "/artifacts/", ""),
+            ("https://artifacts.example.com", "/", "artifacts"),
         )
 
     def test_splitroot_custom_root(self):
         check = self._check_splitroot
 
-        check("http://custom/root", ("http://custom/root", "", ""))
-        check("custom/root", ("custom/root", "", ""))
-        check("https://custom/root", ("https://custom/root", "", ""))
-        check("http://custom/root/", ("http://custom/root", "", ""))
+        check("http://custom/root", ("http://custom/root", "/", ""))
+        check("custom/root", ("custom/root", "/", ""))
+        check("https://custom/root", ("https://custom/root", "/", ""))
+        check("http://custom/root/", ("http://custom/root", "/", ""))
         check(
             "http://custom/root/artifactory",
-            ("http://custom/root", "/artifactory/", ""),
+            ("http://custom/root", "/", "artifactory"),
         )
-        check("http://custom/root/foo/bar", ("http://custom/root", "/foo/", "bar"))
-        check("https://custom/root/foo/baz", ("https://custom/root", "/foo/", "baz"))
+        check("http://custom/root/foo/bar", ("http://custom/root", "/", "foo/bar"))
+        check("https://custom/root/foo/baz", ("https://custom/root", "/", "foo/baz"))
         check(
             "https://custom/root/foo/with/artifactory/folder/baz",
-            ("https://custom/root", "/foo/", "with/artifactory/folder/baz"),
+            ("https://custom/root", "/", "foo/with/artifactory/folder/baz"),
         )
 
     def test_parse_parts(self):
@@ -282,15 +282,15 @@ class ArtifactoryFlavorTest(unittest.TestCase):
 
         check(
             ["http://b/artifactory/c/d.xml"],
-            ("http://b/artifactory", "/c/", ["http://b/artifactory/c/", "d.xml"]),
+            ("http://b/artifactory", "/", ["http://b/artifactory/", "c", "d.xml"]),
         )
 
         check(
             ["http://example.com/artifactory/foo"],
             (
                 "http://example.com/artifactory",
-                "/foo/",
-                ["http://example.com/artifactory/foo/"],
+                "/",
+                ["http://example.com/artifactory/", "foo"],
             ),
         )
 
@@ -298,8 +298,8 @@ class ArtifactoryFlavorTest(unittest.TestCase):
             ["http://example.com/artifactory/foo/bar"],
             (
                 "http://example.com/artifactory",
-                "/foo/",
-                ["http://example.com/artifactory/foo/", "bar"],
+                "/",
+                ["http://example.com/artifactory/", "foo", "bar"],
             ),
         )
 
@@ -307,8 +307,8 @@ class ArtifactoryFlavorTest(unittest.TestCase):
             ["http://example.com/artifactory/foo/bar/artifactory"],
             (
                 "http://example.com/artifactory",
-                "/foo/",
-                ["http://example.com/artifactory/foo/", "bar", "artifactory"],
+                "/",
+                ["http://example.com/artifactory/", "foo", "bar", "artifactory"],
             ),
         )
 
@@ -316,8 +316,8 @@ class ArtifactoryFlavorTest(unittest.TestCase):
             ["http://example.com/artifactory/foo/bar/artifactory/fi"],
             (
                 "http://example.com/artifactory",
-                "/foo/",
-                ["http://example.com/artifactory/foo/", "bar", "artifactory", "fi"],
+                "/",
+                ["http://example.com/artifactory/", "foo", "bar", "artifactory", "fi"],
             ),
         )
 
@@ -328,14 +328,14 @@ class PureArtifactoryPathTest(unittest.TestCase):
     def test_root(self):
         P = self.cls
 
-        self.assertEqual(P("http://a/artifactory/b").root, "/b/")
+        self.assertEqual(P("http://a/artifactory/b").root, "/")
 
-        self.assertEqual(P("http://a/artifactory/").root, "")
+        self.assertEqual(P("http://a/artifactory/").root, "/")
 
     def test_anchor(self):
         P = self.cls
         b = P("http://b/artifactory/c/d.xml")
-        self.assertEqual(b.anchor, "http://b/artifactory/c/")
+        self.assertEqual(b.anchor, "http://b/artifactory/")
 
     def test_with_suffix(self):
         P = self.cls
@@ -984,7 +984,9 @@ class ArtifactoryPathTest(ClassSetup):
                         f"{static_matrix_parameters};prop%3FB=a%0b;prop?C=see;propA=a?b"
                     )
 
-                item_constructed_url = f"{path}{test_file.name};{matrix_parameters}"
+                item_constructed_url = (
+                    f"{path.joinpath(test_file.name)};{matrix_parameters}"
+                )
                 responses.add(responses.PUT, item_constructed_url, status=200)
 
                 path.deploy_file(
@@ -1191,7 +1193,7 @@ class ArtifactoryPathTest(ClassSetup):
             test_file = pathlib.Path(file.name)
             file.write("I am a test file")
 
-            constructed_url = f"{path}{test_file.name};{matrix_parameters}"
+            constructed_url = f"{path.joinpath(test_file.name)};{matrix_parameters}"
             responses.add(responses.PUT, constructed_url, status=200)
 
             path.deploy_deb(
@@ -1245,15 +1247,17 @@ class ArtifactoryPathTest(ClassSetup):
         """
         https://github.com/devopshq/artifactory/issues/239
         """
-
         P = self.cls
-        artis = ["", "artifactory", "artifactory/"]
+        artis = ["artifactory", "artifactory/"]
         reponames = ["reponame", "/reponame", "reponame/", "/reponame/"]
 
-        for arti in artis:
-            for reponame in reponames:
+        for reponame in reponames:
+            c = P("http://b/").joinpath(reponame)
+            self.assertEqual(str(c), "http://b/reponame")
+
+            for arti in artis:
                 c = P("http://b/" + arti).joinpath(reponame)
-                self.assertEqual(c.root, "/reponame/")
+                self.assertEqual(str(c), "http://b/artifactory/reponame")
 
     @responses.activate
     def test_archive(self):
@@ -1426,7 +1430,7 @@ class TestArtifactoryAql(unittest.TestCase):
         artifact = self.aql.from_aql(result)
         assert artifact.drive == "http://b/artifactory"
         assert artifact.name == "name.nupkg"
-        assert artifact.root == "/reponame/"
+        assert artifact.root == "/"
 
 
 class TestArtifactoryPathGetAll(unittest.TestCase):

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -66,14 +66,15 @@ class UtilTest(unittest.TestCase):
 class ArtifactoryFlavorTest(unittest.TestCase):
     flavour = artifactory._artifactory_flavour
 
-    def _check_parse_parts(self, arg, expected):
-        f = self.flavour.parse_parts
+    def _check_parse_path(self, arg, expected):
+        # f = self.flavour.parse_path
+        f = ArtifactoryPath._parse_path
         sep = self.flavour.sep
         altsep = self.flavour.altsep
-        actual = f([x.replace("/", sep) for x in arg])
+        actual = f(arg.replace("/", sep))
         self.assertEqual(actual, expected)
         if altsep:
-            actual = f([x.replace("/", altsep) for x in arg])
+            actual = f(arg.replace("/", altsep))
             self.assertEqual(actual, expected)
 
     def setUp(self):
@@ -275,49 +276,49 @@ class ArtifactoryFlavorTest(unittest.TestCase):
             ("https://custom/root", "/", "foo/with/artifactory/folder/baz"),
         )
 
-    def test_parse_parts(self):
-        check = self._check_parse_parts
+    def test_parse_path(self):
+        check = self._check_parse_path
 
-        check([".txt"], ("", "", [".txt"]))
+        check(".txt", ("", "", [".txt"]))
 
         check(
-            ["http://b/artifactory/c/d.xml"],
-            ("http://b/artifactory", "/", ["http://b/artifactory/", "c", "d.xml"]),
+            "http://b/artifactory/c/d.xml",
+            ("http://b/artifactory", "/", ["c", "d.xml"]),
         )
 
         check(
-            ["http://example.com/artifactory/foo"],
+            "http://example.com/artifactory/foo",
             (
                 "http://example.com/artifactory",
                 "/",
-                ["http://example.com/artifactory/", "foo"],
+                ["foo"],
             ),
         )
 
         check(
-            ["http://example.com/artifactory/foo/bar"],
+            "http://example.com/artifactory/foo/bar",
             (
                 "http://example.com/artifactory",
                 "/",
-                ["http://example.com/artifactory/", "foo", "bar"],
+                ["foo", "bar"],
             ),
         )
 
         check(
-            ["http://example.com/artifactory/foo/bar/artifactory"],
+            "http://example.com/artifactory/foo/bar/artifactory",
             (
                 "http://example.com/artifactory",
                 "/",
-                ["http://example.com/artifactory/", "foo", "bar", "artifactory"],
+                ["foo", "bar", "artifactory"],
             ),
         )
 
         check(
-            ["http://example.com/artifactory/foo/bar/artifactory/fi"],
+            "http://example.com/artifactory/foo/bar/artifactory/fi",
             (
                 "http://example.com/artifactory",
                 "/",
-                ["http://example.com/artifactory/", "foo", "bar", "artifactory", "fi"],
+                ["foo", "bar", "artifactory", "fi"],
             ),
         )
 
@@ -405,6 +406,23 @@ class PureArtifactoryPathTest(unittest.TestCase):
         self.assertEqual(
             str(c),
             "http://b/artifactory/reponame/path/with/multiple/subdir/and/artifactory/path.txt",
+        )
+
+    def test_join_full_path(self):
+        """
+        The method "archive" relies on this behavior, although I think the operation of joining two full
+        paths is not really well defined. Anyway, this is the behavior of pathlib.Path, so lets copy it.
+        """
+        P = self.cls
+
+        b = P("http://b/artifactory/reponame")
+        c = (
+            b
+            / "http://c/artifactory/repo2/path/with/multiple/subdir/and/artifactory/path.txt"
+        )
+        self.assertEqual(
+            str(c),
+            "http://c/artifactory/repo2/path/with/multiple/subdir/and/artifactory/path.txt",
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py37
     py38
     py39
     py310
     py311
+    py312
     pre-commit
 
 [testenv]
@@ -14,7 +14,9 @@ commands =
 
 [testenv:pre-commit]
 skip_install = true
-deps = pre-commit
+deps =
+      pre-commit
+      setuptools
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [flake8]


### PR DESCRIPTION
Hi,

I took a stab at addressing #430, let me describe a little bit the changes because it ended up being a larger PR than what I intended.

The PR is split in 3 commits:
1. Breaking change that made migrating to python's 3.12 pathlib much easier.
2. Make code work and all unit tests pass under python3.12, but break when <= 3.11
3. Make code work in 3.8 - 3.11, and fix tox/pre-commit when running under python3.12.

## Why did I have to make a breaking change
First, I tried just upgrading to python 3.12 and working around the changes done in `pathlib.PurePath`, but I was having to copy/paste and slightly tweak a lot of methods because of the choice of using the first part of the path as the "root".

An example of what I mean:

```python3
# This should be true
ArtifactoryPath('http://b.com/artifactory/repo/path/file.txt').is_relative_to('http://b.com/artifactory') == False
```
This is because the second path doesn't have a root, but IMO this is a relative path.

So, to fix that I've made the first commit, which is changing in python3.11 and before the way the root is handled. This is how the behavior changes, and that may be a BREAKING change, so I am not sure if that is acceptable or not.

```python3
# Current behavior
_ArtifactoryFlavour().splitroot('http://b.com/artifactory/repo/folder/file.txt') == ('http://b.com/artifactory', '/repo/', 'folder/file.txt')

# New behavior
_ArtifactoryFlavour().splitroot('http://b.com/artifactory/repo/folder/file.txt') == ('http://b.com/artifactory', '/', 'repo/folder/file.txt')
```

I think this may not be so bad, since most of the interface is internal. If a code is using `ArtifactoryPath.root` this will change, if it is using `ArtifactoryPath.repo` it is backwards compatible.

## Final comments

After that change, the migration was much easier. Commit 2 is making the code work in python3.12, and commit 3 is making it work at the same time in python3.12 AND in older python versions.

There are some small changes in precommit files that I had to do to make sure they would work when tox is invoked under python3.12, but I can drop those if needed, or open a separate PR.


Last thing: All unit tests pass, but I couldn't get a trial license to integration test those changes, so I didn't run that, sorry.

Let me know if I can do anything to help the review!
