### PR TITLE
Fix the issue when the top level domain was trimmed

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -2463,7 +2463,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         "return: A list of found objects
         """
         if cls is Project:
-            request_url = self.drive.rstrip("/artifactory") + url
+            request_url = self.drive.replace("/artifactory", "") + url
         else:
             request_url = self.drive + url
         response = self.session.get(request_url, auth=self.auth)

--- a/artifactory.py
+++ b/artifactory.py
@@ -2463,7 +2463,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         "return: A list of found objects
         """
         if cls is Project:
-            request_url = self.drive.replace("/artifactory", "") + url
+            request_url = re.sub(r"/artifactory$", "", self.drive) + url
         else:
             request_url = self.drive + url
         response = self.session.get(request_url, auth=self.auth)


### PR DESCRIPTION
Take simple example

```python
'https://canonical.jfrog.io'.rstrip("/artifactory")
``` 
results in
```python
'https://canonical.jfrog.'
``` 
