### PR TITLE
GH-467: fix `ArtifactoryPath.__reduce__` for python 3.9 and below

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -34,7 +34,6 @@ import os
 import pathlib
 import platform
 import re
-import sys
 import urllib.parse
 from itertools import islice, chain
 
@@ -51,6 +50,7 @@ from dohq_artifactory.admin import RepositoryVirtual
 from dohq_artifactory.admin import User
 from dohq_artifactory.auth import XJFrogArtApiAuth
 from dohq_artifactory.auth import XJFrogArtBearerAuth
+from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 from dohq_artifactory.exception import ArtifactoryException
 from dohq_artifactory.exception import raise_for_status
 from dohq_artifactory.logger import logger
@@ -1498,9 +1498,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
     on regular constructors, but rather on templates.
     """
 
-    if sys.version_info.major == 3 and sys.version_info.minor >= 10:
-        # see changes in pathlib.Path, slots are no more applied
-        # https://github.com/python/cpython/blob/ce121fd8755d4db9511ce4aab39d0577165e118e/Lib/pathlib.py#L952
+    if IS_PYTHON_3_10_OR_NEWER:
         _accessor = _artifactory_accessor
     else:
         # in 3.9 and below Pathlib limits what members can be present in 'Path' class
@@ -1806,7 +1804,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.timeout = self.timeout
         return obj
 
-    if sys.version_info < (3,):
+    if IS_PYTHON_2:
         __div__ = __truediv__
         __rdiv__ = __rtruediv__
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -35,7 +35,8 @@ import pathlib
 import platform
 import re
 import urllib.parse
-from itertools import islice, chain
+from itertools import chain
+from itertools import islice
 
 import dateutil.parser
 import requests
@@ -878,7 +879,11 @@ class _ArtifactoryAccessor:
         )
         code = response.status_code
         text = response.text
-        if code == 404 and ("Unable to find item" in text or "Not Found" in text or "File not found" in text):
+        if code == 404 and (
+            "Unable to find item" in text
+            or "Not Found" in text
+            or "File not found" in text
+        ):
             raise OSError(2, f"No such file or directory: {url}")
 
         raise_for_status(response)
@@ -1585,7 +1590,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
             memo[id(self._cache)] = self._cache.__new__(dict)
 
         # Get all __slots__ of the derived class
-        slots = chain.from_iterable(getattr(s, "__slots__", []) for s in self.__class__.__mro__)
+        slots = chain.from_iterable(
+            getattr(s, "__slots__", []) for s in self.__class__.__mro__
+        )
 
         # Deep copy all other attributes
         for var in slots:

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -9,6 +9,7 @@ import warnings
 import jwt
 from dateutil.parser import isoparse
 
+from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 from dohq_artifactory.exception import ArtifactoryException
 from dohq_artifactory.exception import raise_for_status
 from dohq_artifactory.logger import logger
@@ -51,10 +52,10 @@ def _new_function_with_secret_module(pw_len=16):
     return "".join(secrets.choice(string.ascii_letters) for i in range(pw_len))
 
 
-if sys.version_info < (3, 6):
-    generate_password = _old_function_for_secret
-else:
+if IS_PYTHON_3_6_OR_NEWER:
     generate_password = _new_function_with_secret_module
+else:
+    generate_password = _old_function_for_secret
 
 
 def deprecation(message):
@@ -656,7 +657,7 @@ class GenericRepository(AdminObject):
     def __rtruediv__(self, key):
         return self.path.__truediv__(key)
 
-    if sys.version_info < (3,):
+    if IS_PYTHON_2:
         __div__ = __truediv__
         __rdiv__ = __rtruediv__
 

--- a/dohq_artifactory/admin.py
+++ b/dohq_artifactory/admin.py
@@ -2,7 +2,6 @@ import json
 import random
 import re
 import string
-import sys
 import time
 import warnings
 
@@ -866,7 +865,7 @@ class RepositoryVirtual(GenericRepository):
         package_type=Repository.GENERIC,
         *,
         packageType=None,
-        default_deployment_repo_name=None
+        default_deployment_repo_name=None,
     ):
         super(RepositoryVirtual, self).__init__(artifactory)
         self.name = name
@@ -896,7 +895,7 @@ class RepositoryVirtual(GenericRepository):
             "packageType": self.package_type,
             "repositories": self._repositories,
             "notes": self.notes,
-            "defaultDeploymentRepo": self.default_deployment_repo_name
+            "defaultDeploymentRepo": self.default_deployment_repo_name,
         }
 
         return data_json

--- a/dohq_artifactory/compat.py
+++ b/dohq_artifactory/compat.py
@@ -1,0 +1,7 @@
+import sys
+
+IS_PYTHON_2 = sys.version_info < (3,)
+IS_PYTHON_3_6_OR_NEWER = sys.version_info >= (3, 6)
+# see changes in pathlib.Path, slots are no more applied
+# https://github.com/python/cpython/blob/ce121fd8755d4db9511ce4aab39d0577165e118e/Lib/pathlib.py#L952
+IS_PYTHON_3_10_OR_NEWER = sys.version_info >= (3, 10)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 
 import pytest
 
 from artifactory import ArtifactoryPath
-from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 from dohq_artifactory import Group
 from dohq_artifactory import PermissionTarget
 from dohq_artifactory import RepositoryLocal
 from dohq_artifactory import User
+from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 
 if IS_PYTHON_2:
     import ConfigParser as configparser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,13 @@ import sys
 import pytest
 
 from artifactory import ArtifactoryPath
+from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 from dohq_artifactory import Group
 from dohq_artifactory import PermissionTarget
 from dohq_artifactory import RepositoryLocal
 from dohq_artifactory import User
 
-if sys.version_info[0] < 3:
+if IS_PYTHON_2:
     import ConfigParser as configparser
 else:
     import configparser

--- a/tests/integration/test_integration_artifactory_path.py
+++ b/tests/integration/test_integration_artifactory_path.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import copy
-import sys
 import tempfile
 
 import pytest
@@ -283,6 +282,7 @@ def test_read_and_write(path):
     assert p.read_text() == "Some test string ensure length > 32"
 
     p.unlink()
+
 
 def test_deepcopy(path):
     p = path("/integration-artifactory-path-repo/foo")

--- a/tests/integration/test_integration_artifactory_path.py
+++ b/tests/integration/test_integration_artifactory_path.py
@@ -8,8 +8,9 @@ import pytest
 import artifactory
 from artifactory import sha1sum
 from artifactory import sha256sum
+from dohq_artifactory.compat import *  # noqa: this helper only contains version flags
 
-if sys.version_info[0] < 3:
+if IS_PYTHON_2:
     import StringIO as io
 else:
     import io

--- a/tests/integration/test_integration_artifactory_path.py
+++ b/tests/integration/test_integration_artifactory_path.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import copy
 import sys
 import tempfile
 
@@ -282,3 +283,11 @@ def test_read_and_write(path):
     assert p.read_text() == "Some test string ensure length > 32"
 
     p.unlink()
+
+def test_deepcopy(path):
+    p = path("/integration-artifactory-path-repo/foo")
+    p2 = copy.deepcopy(p)
+
+    assert p2 == p
+    # different object, same value
+    assert not (p2 is p)

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -102,7 +102,7 @@ class ArtifactoryFlavorTest(unittest.TestCase):
         )
         check(
             "https://example.com/artifactory/foo/example.com/bar",
-            "https://example.com/artifactory/foo/example.com/bar"
+            "https://example.com/artifactory/foo/example.com/bar",
         )
         check(
             "https://example.com/artifactory/foo/#1",


### PR DESCRIPTION
Fixes an issue with DOHQ CrossPM (which was caused indirectly).

Closes #467 