### PR TITLE
Python 3.13 compatibility.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/artifactory.py
+++ b/artifactory.py
@@ -33,6 +33,7 @@ import json
 import os
 import pathlib
 import platform
+import posixpath
 import re
 import urllib.parse
 from itertools import chain
@@ -444,7 +445,7 @@ class _ArtifactoryFlavour(object if IS_PYTHON_3_12_OR_NEWER else pathlib._Flavou
     sep = "/"
     altsep = "/"
     has_drv = True
-    pathmod = pathlib.posixpath
+    pathmod = posixpath
     is_supported = True
 
     def _get_base_url(self, url):
@@ -1499,7 +1500,8 @@ class PureArtifactoryPath(pathlib.PurePath):
     operations.
     """
 
-    _flavour = _artifactory_flavour
+    parser = _artifactory_flavour
+    _flavour = parser  # Compatibility shim for Python < 3.13
     __slots__ = ()
 
     def _init(self, *args):
@@ -1507,7 +1509,7 @@ class PureArtifactoryPath(pathlib.PurePath):
 
     @classmethod
     def _split_root(cls, part):
-        cls._flavour.splitroot(part)
+        cls.parser.splitroot(part)
 
     @classmethod
     def _parse_parts(cls, parts):
@@ -2661,7 +2663,8 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 class ArtifactorySaaSPath(ArtifactoryPath):
     """Class for SaaS Artifactory"""
 
-    _flavour = _saas_artifactory_flavour
+    parser = _saas_artifactory_flavour
+    _flavour = parser  # Compatibility shim for Python < 3.13
 
 
 class ArtifactoryBuild:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Filesystems",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py310
     py311
     py312
+    py313
     pre-commit
 
 [testenv]


### PR DESCRIPTION
Fixes https://github.com/devopshq/artifactory/issues/470.

Between Python 3.12 and Python 3.13, the internal structure of pathlib changed, causing the Artifactory URL parsing to fail. `pathlib.PurePath` previously had a private class attribute, `_flavour`, which has now been renamed to `parser` and made into a public and documented API.

This renames `_flavour` to `parser` in the ArtifactoryPath subclasses, but it leaves around a `_flavour` class attribute that is aliased to `parser` as a compatibility shim for older versions of Python.

One other breakage between Python 3.12 and 3.13 is that the artifactory package attempted to import `posixpath` via the `pathlib` package. `posixpath` was never meant to be a publicly accessible attribute of `pathlib`, as `posixpath` is its own top-level package in the standard library. The `pathlib` code was significantly restructured, causing the `posixpath` module to no longer be accessible under `pathlib`. We fix this in artifactory by directly importing the top-level `posixpath` package.

Finally, this adds Python 3.13 to the package metadata in setup.py and the tox and GitHub Actions configuration files so that it is officially declared as a supported Python version and tested in CI.