### PR TITLE
Replace _make_child_relpath() with public joinpath()

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1923,7 +1923,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         return obj
 
     def _make_child_relpath(self, args):
-        obj = super(ArtifactoryPath, self)._make_child_relpath(args)
+        obj = super(ArtifactoryPath, self).joinpath(args)
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert


### PR DESCRIPTION
Python 3.13 compatibility (#470, #474): Fixes the `AttributeError` mentioned in #473.

With this change I got my [example](https://github.com/devopshq/artifactory/pull/473#issuecomment-2673785371) working on Python 3.13 to 3.9 :+1:.