### PR TITLE
Add unit test for `glob()` and partially fix Python 3.13 case.

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1598,7 +1598,8 @@ class PureArtifactoryPath(pathlib.PurePath):
     # In Python 3.13, this attribute is accessed by PurePath.glob(), and we need to
     # override it to behave properly for ArtifactoryPaths with a custom subclass of
     # glob._Globber.
-    _globber = _ArtifactoryGlobber
+    if IS_PYTHON_3_13_OR_NEWER:
+        _globber = _ArtifactoryGlobber
 
     __slots__ = ()
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -1895,14 +1895,13 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         return self._accessor.scandir(self)
 
     def glob(self, *args, **kwargs):
-        # In Python 3.13, the implementation of Path.glob() changed such that it assumes that it
-        # works only with real filesystem paths and will try to call real filesystem operations like
-        # os.scandir(). In Python 3.13, we explicitly intercept this and call PathBase's glob()
-        # implementation, which only depends on methods defined on the Path subclass.
         if IS_PYTHON_3_13_OR_NEWER:
+            # In Python 3.13, the implementation of Path.glob() changed such that it assumes that it
+            # works only with real filesystem paths and will try to call real filesystem operations like
+            # os.scandir(). In Python 3.13, we explicitly intercept this and call PathBase's glob()
+            # implementation, which only depends on methods defined on the Path subclass.
             return pathlib._abc.PathBase.glob(self, *args, **kwargs)
-        else:
-            return super().glob(*args, **kwargs)
+        return super().glob(*args, **kwargs)
 
     def download_stats(self, pathobj=None):
         """

--- a/artifactory.py
+++ b/artifactory.py
@@ -1516,9 +1516,10 @@ class ArtifactoryOpensourceAccessor(_ArtifactoryAccessor):
 # instance of a Path subclass, since it will normally get normalized away. The match
 # position therefore needs to be incremented by 1 in order to account for the actual
 # slash character that appears when inspecting children of the current directory. This
-# isn't an issue in the actaul use of _Globber in Python, since it converts all paths to
+# isn't an issue in the actual use of _Globber in Python, since it converts all paths to
 # strings, and the add_slash() will literally append a slash character to the string
-# path.
+# path. See the original code in
+# https://github.com/python/cpython/blob/v3.13.2/Lib/glob.py#L448-L510
 class _ArtifactoryGlobber(glob._Globber if IS_PYTHON_3_13_OR_NEWER else object):
     def recursive_selector(self, part, parts):
         """Returns a function that selects a given path and all its children,

--- a/dohq_artifactory/compat.py
+++ b/dohq_artifactory/compat.py
@@ -9,3 +9,7 @@ IS_PYTHON_3_10_OR_NEWER = sys.version_info >= (3, 10)
 # parts of the code once python3.11 is no longer supported. This constant helps
 # identifying those.
 IS_PYTHON_3_12_OR_NEWER = sys.version_info >= (3, 12)
+# Pathlib.Path and glob changed significantly in 3.13, so we will not need several
+# parts of the code once python3.12 is no longer supported. This constant helps
+# identifying those.
+IS_PYTHON_3_13_OR_NEWER = sys.version_info >= (3, 13)


### PR DESCRIPTION
This is a WIP, but I'm submitting it in case if the unit tests are still useful. As reported in https://github.com/devopshq/artifactory/issues/470#issuecomment-2678055698, the `glob()` method no longer works in Python 3.13, returning an empty result regardless of the actual contents in Artifactory.

I haven't gotten this 100% working yet, but I've gotten a little bit closer to fixing it in Python 3.13. It looks like the `pathlib.Path` class changed a lot in Python 3.13 w.r.t. globbing behavior, where in Python 3.12 and lower, there was a [full reimplementation of globbing](https://github.com/python/cpython/blob/v3.12.9/Lib/pathlib.py#L81-L256) inside the `pathlib` module, but in Python 3.13, it now [delegates](https://github.com/python/cpython/blob/v3.13.2/Lib/pathlib/_abc.py#L15) to the actual `glob` package.

One specific issue is that `pathlib._abc.PurePathBase` [depends on the abstract `glob._Globber`](https://github.com/python/cpython/blob/v3.13.2/Lib/pathlib/_abc.py#L121) class, but `pathlib.PurePath` overrides it to depend on [`glob._StringGlobber`](https://github.com/python/cpython/blob/v3.13.2/Lib/pathlib/_local.py#L105). `_StringGlobber` is problematic because it [explicitly uses `os.lstat` and `os.scandir`](https://github.com/python/cpython/blob/v3.13.2/Lib/glob.py#L528-L529) instead of delegating to the Path subclass. What this means is that in Python 3.13, when you call `ArtifactoryPath.glob()`, you eventually end up calling `os.scandir()`, which fails because the path does not actually exist on disk locally.

The reason that `ArtifactoryPath.glob()` returns the empty list rather than throwing an exception is because in Python 3.13, any `OSErrors` that occur while calling `glob()` [are ignored](https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob).

I have a partial fix, where I modified `ArtifactoryPath` to explicitly override the `glob()` method and delegate to `pathlib._abc.PathBase`'s implementation rather than `pathlib.Path`'s implementation (at least in Python 3.13). In the unit test I added, I tried to create mock Artifactory API response data that would correspond to a file tree that looks like:

```
.index/
com/
    foo
    bar
```

My unit test tries to run `glob("**/*")`, and in all Pythons < 3.13, it returns the four results of `.index/`, `com/`, `com/foo`, and `com/bar`. However, in Python 3.13, it currently is only returning the two files and not the directories on their own. I am not sure if my mock data is incorrect yet, or if there is some other Path API that I need to override.

I'm not sure if I'll have time to work on this for the rest of the day (US Pacific time), but I should have time to continue looking in the coming days. In the meantime, I encourage anyone else to take a look at the failures as well.