### PR TITLE
add test_uri() to test_artifactory_path.py

### DIFF
--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -967,6 +967,11 @@ class ArtifactoryPathTest(ClassSetup):
         P = self.cls
         a = P("http://a/artifactory/")
 
+    def test_uri(self):
+        P = self.cls
+        a = P("http://a/artifactory/")
+        self.assertEqual(a.as_uri(), "http://a/artifactory/")
+
     def test_auth(self):
         P = self.cls
         a = P("http://a/artifactory/", auth=("foo", "bar"))


### PR DESCRIPTION
When adding support for Python >= 3.12, https://github.com/devopshq/artifactory/blame/27d86fef653312ebcd86922089a33a939b04de3a/artifactory.py#L432 _ArtifactoryFlavour moved from subclassing pathlib._Flavour to subclassing "object" if _IS_PYTHON_3_12_OR_NEWER and so ArtifactoryPath.as_uri() stopped working. This (in conjunction with the next commit) restores ArtifactoryPath.as_uri() functionality.