### PR TITLE
Fix for issue 407: open() should acceept "rb" attribute.

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -2104,7 +2104,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         HTTPResponse, as if it was a regular filesystem object.
         The only difference is that this object doesn't support seek()
         """
-        if mode not in ["r", "rb"] or buffering != -1 or encoding or errors or newline:
+        if mode not in {"r", "rb"} or buffering != -1 or encoding or errors or newline:
             raise NotImplementedError("Only the default open() arguments are supported")
 
         return self._accessor.open(self)

--- a/artifactory.py
+++ b/artifactory.py
@@ -2104,7 +2104,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         HTTPResponse, as if it was a regular filesystem object.
         The only difference is that this object doesn't support seek()
         """
-        if mode != "r" or buffering != -1 or encoding or errors or newline:
+        if mode not in ["r", "rb"] or buffering != -1 or encoding or errors or newline:
             raise NotImplementedError("Only the default open() arguments are supported")
 
         return self._accessor.open(self)


### PR DESCRIPTION
This fixes  #407 

> This makes code awkward, as I need to specify "rb" to native paths and "r" to artifactory paths, even they are all binary.
Can open function not throw an error when passing "rb" instead of "r" parameter?