### PR TITLE
fixes #450: adds missing support for federated repos in find_repository()

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -47,6 +47,7 @@ from dohq_artifactory.admin import Group
 from dohq_artifactory.admin import PermissionTarget
 from dohq_artifactory.admin import Project
 from dohq_artifactory.admin import Repository
+from dohq_artifactory.admin import RepositoryFederated
 from dohq_artifactory.admin import RepositoryLocal
 from dohq_artifactory.admin import RepositoryRemote
 from dohq_artifactory.admin import RepositoryVirtual
@@ -2694,6 +2695,12 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
             return obj
         return None
 
+    def find_repository_federated(self, name):
+        obj = RepositoryFederated(self, name)
+        if obj.read():
+            return obj
+        return None
+
     def find_repository_virtual(self, name):
         obj = RepositoryVirtual(self, name)
         if obj.read():
@@ -2709,6 +2716,11 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
     def find_repository(self, name):
         try:
             return self.find_repository_local(name)
+        except ArtifactoryException:
+            pass
+
+        try:
+            return self.find_repository_federated(name)
         except ArtifactoryException:
             pass
 


### PR DESCRIPTION
Fixes #450 

Tested this on a productive instance. Without this patch the `repositories` property of an object of type `RepositoryVirtual` will return `None` when it hits a repository of type 'federated' because that repo type was not handled in `find_repository()` which then defaults to `None`.

`tox` came back clean for all python versions on linux but pre-commit:blacken-docs complained about syntax issues in a python snippet in the `README.md`. I added it as a bonus commit so it also comes back clean.