### PR TITLE
Add project query param to build APIs

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -2983,11 +2983,7 @@ class ArtifactoryBuildManager(ArtifactoryPath):
         :return: (list) list of available build names
         """
         all_builds = []
-        url = ""
-        if self.project:
-            url = f"?project='{self.project}'"
-
-        resp = self._get_build_api_response(url)
+        resp = self._get_build_api_response(self._add_project(""))
         if "builds" in resp:
             for build in resp["builds"]:
                 arti_build = ArtifactoryBuild(
@@ -3030,6 +3026,17 @@ class ArtifactoryBuildManager(ArtifactoryPath):
         """
         return self._get_info(build_name, build_number)
 
+    def _add_project(self, url):
+        """
+        Add the project of this build manager as a query parameter to the build API url
+        :param url: (str) build API url, may already contain a query string
+        :return: (str) url with the project query parameter
+        """
+        if not self.project:
+            return url
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}project={self.project}"
+
     def _get_info(self, build_name, build_number=""):
         # If a build name contains slash "/" it must be encoded,
         # otherwise the part after the slash will be treated as a build number
@@ -3038,7 +3045,7 @@ class ArtifactoryBuildManager(ArtifactoryPath):
         if build_number:
             build_number = urllib.parse.quote(str(build_number), safe="")
             url += f"/{build_number}"
-        return self._get_build_api_response(url)
+        return self._get_build_api_response(self._add_project(url))
 
     def _get_build_api_response(self, url):
         url = f"{self.drive}/api/build/{url}"
@@ -3058,7 +3065,7 @@ class ArtifactoryBuildManager(ArtifactoryPath):
         build_number1 = urllib.parse.quote(str(build_number1), safe="")
         build_number2 = urllib.parse.quote(str(build_number2), safe="")
         url = f"{build_name}/{build_number1}?diff={build_number2}"
-        return self._get_build_api_response(url)
+        return self._get_build_api_response(self._add_project(url))
 
     def promote_build(
         self,
@@ -3137,8 +3144,13 @@ class ArtifactoryBuildManager(ArtifactoryPath):
 
             json_data["scopes"] = scopes
 
+        # the url is percent-encoded by rest_post, so the project has to be passed
+        # as a request parameter instead of being appended to the url
+        params = {"project": self.project} if self.project else None
+
         self._accessor.rest_post(
             url,
+            params=params,
             json_data=json_data,
             session=self.session,
             verify=self.verify,

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 import os
 import pathlib
 import sys
@@ -1877,6 +1878,157 @@ class TestArtifactoryPathGetAll(unittest.TestCase):
 
             self.assertEqual(len(rsps.calls), 1)
             self.assertEqual(rsps.calls[0].request.url, self.projects_request_url)
+
+
+class ArtifactoryBuildManagerTest(unittest.TestCase):
+    """Test that the project of the build manager is sent to the build API"""
+
+    def setUp(self):
+        self.base_url = "http://artifactory.local/artifactory"
+        self.build_manager = artifactory.ArtifactoryBuildManager(
+            self.base_url, project="test-project", auth=("admin", "admin")
+        )
+        self.build_manager_without_project = artifactory.ArtifactoryBuildManager(
+            self.base_url, auth=("admin", "admin")
+        )
+
+    @responses.activate
+    def test_builds(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build/",
+            json={
+                "builds": [
+                    {"uri": "/my-build", "lastStarted": "2025-01-01T00:00:00.000Z"},
+                ]
+            },
+            status=200,
+        )
+
+        builds = self.build_manager.builds
+
+        self.assertEqual(len(builds), 1)
+        self.assertEqual(builds[0].name, "my-build")
+        # the project is sent as a bare key, the API rejects quoted ones
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/?project=test-project",
+        )
+
+    @responses.activate
+    def test_builds_without_project(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build",
+            json={"builds": []},
+            status=200,
+        )
+
+        self.build_manager_without_project.builds
+
+        self.assertEqual(responses.calls[0].request.url, f"{self.base_url}/api/build")
+
+    @responses.activate
+    def test_get_build_runs(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build/my-build",
+            json={"buildsNumbers": [{"uri": "/1", "started": "2025-01-01"}]},
+            status=200,
+        )
+
+        runs = self.build_manager.get_build_runs("my-build")
+
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/my-build?project=test-project",
+        )
+
+    @responses.activate
+    def test_get_build_info(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build/my-build/456",
+            json={"buildInfo": {}},
+            status=200,
+        )
+
+        self.build_manager.get_build_info("my-build", "456")
+
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/my-build/456?project=test-project",
+        )
+
+    @responses.activate
+    def test_get_build_info_without_project(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build/my-build/456",
+            json={"buildInfo": {}},
+            status=200,
+        )
+
+        self.build_manager_without_project.get_build_info("my-build", "456")
+
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/my-build/456",
+        )
+
+    @responses.activate
+    def test_get_build_diff(self):
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/api/build/my-build/456",
+            json={"artifacts": {}},
+            status=200,
+        )
+
+        self.build_manager.get_build_diff("my-build", "456", "123")
+
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/my-build/456?diff=123&project=test-project",
+        )
+
+    @responses.activate
+    def test_promote_build(self):
+        responses.add(
+            responses.POST,
+            f"{self.base_url}/api/build/promote/my-build/456",
+            status=200,
+        )
+
+        self.build_manager.promote_build(
+            "my-build", "456", ci_user="admin", properties={"release": ["1.0"]}
+        )
+
+        request = responses.calls[0].request
+        self.assertEqual(
+            request.url,
+            f"{self.base_url}/api/build/promote/my-build/456?project=test-project",
+        )
+        # the promotion API takes the project as a query parameter, not in the body
+        self.assertNotIn("project", json.loads(request.body))
+
+    @responses.activate
+    def test_promote_build_without_project(self):
+        responses.add(
+            responses.POST,
+            f"{self.base_url}/api/build/promote/my-build/456",
+            status=200,
+        )
+
+        self.build_manager_without_project.promote_build(
+            "my-build", "456", ci_user="admin", properties={"release": ["1.0"]}
+        )
+
+        self.assertEqual(
+            responses.calls[0].request.url,
+            f"{self.base_url}/api/build/promote/my-build/456",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #452. Combines #493 and #486, co-authored by @gjed and @donhui.

On top of what those PRs did: `get_build_diff()` had the same bug, and `promote_build()` sends the project as a **query parameter**, not a JSON body field — that's how JFrog's own client does it ([jfrog-client-go promote.go#L39-L41](https://github.com/jfrog/jfrog-client-go/blob/de0c68a23c435425f5e30e5a1befb0ec618588f0/artifactory/services/promote.go#L39-L41)), and `rest_post()` would percent-encode a hand-appended `?` anyway.

@beliaev-maksim re: dropping the quotes — they were a bug, Artifactory expects a bare key, and spaces in project names can't happen: a Project Key "supports 2 to 32 lowercase alphanumeric characters and hyphens, and must start with a letter" ([docs](https://docs.jfrog.com/projects/docs/create-a-project)).

[![Patreon](https://img.shields.io/badge/Patreon-000000?logo=patreon&logoColor=white)](https://patreon.com/allburov) [![Boosty](https://img.shields.io/badge/Boosty-f15f2c?logo=boosty&logoColor=white)](https://boosty.to/allburov)