### PR TITLE
Add stat_json() to get the raw file info from Artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,21 @@ print(stat.children)
 print(stat.repo)
 ```
 
+`stat()` exposes a fixed set of fields. To get the file info exactly as Artifactory returns it,
+including fields like `downloadUri` and `path`, use `stat_json()`:
+
+```python
+from artifactory import ArtifactoryPath
+
+path = ArtifactoryPath(
+    "http://repo.jfrog.org/artifactory/distributions/org/apache/tomcat/apache-tomcat-7.0.11.tar.gz"
+)
+
+stat = path.stat_json()
+print(stat["downloadUri"])
+print(stat["path"])
+```
+
 ### Get Download Statistics
 Information about number of downloads, user that last downloaded and date of last download
 ```python

--- a/artifactory.py
+++ b/artifactory.py
@@ -1891,6 +1891,19 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         pathobj = pathobj or self
         return self._accessor.stat(pathobj=pathobj)
 
+    def stat_json(self, pathobj=None):
+        """
+        Request remote file/directory status info
+        Returns the raw json object as specified by Artifactory REST API,
+        with all the fields the server provides, eg 'downloadUri' or 'path'.
+        Unlike stat(), the fields are not parsed and depend on the Artifactory version
+        and on the kind of the artifact, so prefer stat() whenever it exposes the field
+        :param pathobj: (Optional) path like object for which to get stats.
+            if None is provided then applied to ArtifactoryPath itself
+        """
+        pathobj = pathobj or self
+        return self._accessor.get_stat_json(pathobj=pathobj)
+
     def exists(self):
         try:
             self.stat()

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -973,6 +973,54 @@ class ArtifactoryPathTest(ClassSetup):
         self.assertEqual(a.auth, ("foo", "bar"))
 
     @responses.activate
+    def test_stat_json(self):
+        """
+        Test that stat_json returns the file info as provided by Artifactory,
+        including the fields that stat() does not expose
+        """
+        path = self.cls(self.artifact_url)
+
+        constructed_url = (
+            "http://artifactory.local/artifactory"
+            "/api/storage"
+            "/ext-release-local/org/company/tool/1.0/tool-1.0.tar.gz"
+        )
+        responses.add(
+            responses.GET,
+            constructed_url,
+            status=200,
+            json=self.file_stat,
+        )
+
+        stats = path.stat_json()
+
+        self.assertEqual(stats, self.file_stat)
+        self.assertEqual(stats["path"], "/org/company/tool/1.0/tool-1.0.tar.gz")
+        self.assertEqual(stats["downloadUri"], self.artifact_url)
+
+    @responses.activate
+    def test_stat_json_folder(self):
+        """
+        Test that stat_json works for a folder, which has no downloadUri
+        """
+        path = self.cls("http://artifactory.local/artifactory/libs-release-local")
+
+        constructed_url = (
+            "http://artifactory.local/artifactory" "/api/storage" "/libs-release-local"
+        )
+        responses.add(
+            responses.GET,
+            constructed_url,
+            status=200,
+            json=self.dir_stat,
+        )
+
+        stats = path.stat_json()
+
+        self.assertEqual(stats, self.dir_stat)
+        self.assertNotIn("downloadUri", stats)
+
+    @responses.activate
     def test_deploy_file(self):
         """
         Test that file uploads to the path


### PR DESCRIPTION
Closes #488, co-authored by @donhui.

#488 wanted `path` and `downloadUri` from the File Info API. Rather than add them to the `ArtifactoryFileStat` namedtuple, this exposes the raw response: `stat()` keeps a fixed documented field set, like `pathlib.Path.stat()` returning an `os.stat_result`, and `stat_json()` gives everything the server sends — including any field JFrog adds later.

The accessor already had `get_stat_json()`; it was just unreachable without touching `path._accessor`.

```python
stat = path.stat_json()
print(stat["downloadUri"])
print(stat["path"])
```

[![Patreon](https://img.shields.io/badge/Patreon-000000?logo=patreon&logoColor=white)](https://patreon.com/allburov) [![Boosty](https://img.shields.io/badge/Boosty-f15f2c?logo=boosty&logoColor=white)](https://boosty.to/allburov)