### PR TITLE
Use the session's verify when it is not passed explicitly

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1704,6 +1704,10 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
             obj.verify = kwargs.get("verify")
         elif cfg_entry:
             obj.verify = cfg_entry["verify"]
+        elif obj.session is not None:
+            # the session is passed to requests along with verify, and the explicit
+            # verify wins over the one of the session, so take it from the session
+            obj.verify = obj.session.verify
         else:
             obj.verify = True
 
@@ -1782,6 +1786,10 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
             self.verify = custom_kwargs.get("verify")
         elif cfg_entry:
             self.verify = cfg_entry["verify"]
+        elif self.session is not None:
+            # the session is passed to requests along with verify, and the explicit
+            # verify wins over the one of the session, so take it from the session
+            self.verify = self.session.verify
         else:
             self.verify = True
 

--- a/tests/unit/test_artifactory_path.py
+++ b/tests/unit/test_artifactory_path.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 
 import dateutil
+import requests
 import responses
 from responses.matchers import json_params_matcher
 from responses.matchers import query_param_matcher
@@ -971,6 +972,40 @@ class ArtifactoryPathTest(ClassSetup):
         P = self.cls
         a = P("http://a/artifactory/", auth=("foo", "bar"))
         self.assertEqual(a.auth, ("foo", "bar"))
+
+    def test_verify_from_session(self):
+        """
+        Test that the verify of the given session is used when verify is not passed,
+        otherwise the default one would override it when the request is made
+        """
+        P = self.cls
+        session = requests.Session()
+        session.verify = False
+
+        a = P("http://a/artifactory/", session=session)
+
+        self.assertEqual(a.verify, False)
+
+    def test_verify_overrides_session(self):
+        """
+        Test that an explicit verify wins over the one of the given session
+        """
+        P = self.cls
+        session = requests.Session()
+        session.verify = False
+
+        a = P("http://a/artifactory/", session=session, verify=True)
+
+        self.assertEqual(a.verify, True)
+
+    def test_verify_default(self):
+        """
+        Test that verify is enabled when neither a session nor verify is given
+        """
+        P = self.cls
+        a = P("http://a/artifactory/")
+
+        self.assertEqual(a.verify, True)
 
     @responses.activate
     def test_deploy_file(self):


### PR DESCRIPTION
Fixes #500.

Passing a session with TLS verification disabled had no effect:

```python
session = requests.Session()
session.verify = False
path = ArtifactoryPath("https://artifactory.local/artifactory/repo", session=session)
# requests were still made with verify=True
```

`ArtifactoryPath` defaulted `verify` to `True` and passed it to every request explicitly. Requests gives a request-level argument precedence over the session's own setting, so `session.verify` was always discarded.

Now `verify` falls back to the session when it is not given, in both constructors. The precedence becomes: explicit `verify=` → config file entry → `session.verify` → `True`. Callers who pass no session are unaffected, and a session that never set `verify` still yields `True`, since that is the default in requests.

[![Patreon](https://img.shields.io/badge/Patreon-000000?logo=patreon&logoColor=white)](https://patreon.com/allburov) [![Boosty](https://img.shields.io/badge/Boosty-f15f2c?logo=boosty&logoColor=white)](https://boosty.to/allburov)