### PR TITLE
fix: respect session verify attribute in ArtifactPath constructor

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -1702,6 +1702,10 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         if "verify" in kwargs:
             obj.verify = kwargs.get("verify")
+        elif obj.session is not None and hasattr(obj.session, "verify"):
+            # Use session's verify attribute if session was provided
+            # and verify was not explicitly passed
+            obj.verify = obj.session.verify
         elif cfg_entry:
             obj.verify = cfg_entry["verify"]
         else:
@@ -1780,6 +1784,10 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
 
         if "verify" in custom_kwargs:
             self.verify = custom_kwargs.get("verify")
+        elif self.session is not None and hasattr(self.session, "verify"):
+            # Use session's verify attribute if session was provided
+            # and verify was not explicitly passed
+            self.verify = self.session.verify
         elif cfg_entry:
             self.verify = cfg_entry["verify"]
         else:


### PR DESCRIPTION
## WHAT

Fix Session 'verify' attribute being ignored when constructing ArtifactPath

## Root Cause

When passing a `requests.Session` with `verify=False` to `ArtifactPath()`, the constructor ignores the session's `verify` setting and defaults to `True` (or the config file value). This happens in both `__new__` (Python <3.12) and `__init__` (Python >=3.12) methods.

## Solution

When a session is provided but `verify` is not explicitly passed as a keyword argument, inherit the `verify` value from the session object instead of falling through to the hardcoded default. Explicit `verify` kwargs still take precedence over the session.

## Test Plan

```python
import requests
from artifactory import ArtifactoryPath

session = requests.Session()
session.verify = False
path = ArtifactoryPath("http://example.com/artifactory/libs-release-local/foo", session=session)
assert path.verify is False, "Session verify should be inherited"
```

Fixes #500
